### PR TITLE
Fix #3: don't end @ strings at an "" occurrence

### DIFF
--- a/fsharp.json
+++ b/fsharp.json
@@ -316,7 +316,7 @@
               {
                   "name": "string.quoted.literal.fsharp",
                   "begin": "(?=[^\\\\])(@\")",
-                  "end": "(\")",
+                  "end": "(\")(?!\")",
                   "beginCaptures": {
                       "1": {
                           "name": "punctuation.definition.string.begin.fsharp"


### PR DESCRIPTION
Literal strings interpret `""` as a single `"` character, so the end-of-string regex should take that into account.