### PR TITLE
Add paket grammars

### DIFF
--- a/paket.dependencies.json
+++ b/paket.dependencies.json
@@ -1,0 +1,134 @@
+{
+  "fileTypes": [
+    "paket.dependencies"
+  ],
+  "foldingStartMarker": "",
+  "foldingStopMarker": "",
+  "name": "Paket",
+  "patterns": [
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#line-comments"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#definition"
+    },
+    {
+      "include": "#keywords"
+    }
+  ],
+  "repository": {
+    "characters": {
+      "patterns": [
+        {
+          "begin": "(')",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.begin.paket"
+            }
+          },
+          "end": "(')",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.end.paket"
+            }
+          },
+          "name": "string.quoted.single.paket",
+          "patterns": [
+            {
+              "match": "\\\\$[ \\t]*",
+              "name": "punctuation.separator.string.ignore-eol.paket"
+            },
+            {
+              "match": "\\\\([\\\\\"\"ntbr]|u[a-fA-F0-9]{4}|u[a-fA-F0-9]{8})",
+              "name": "constant.character.string.escape.paket"
+            },
+            {
+              "match": "\\\\(?![\\\\'ntbr]|u[a-fA-F0-9]{4}|u[a-fA-F0-9]{8}).",
+              "name": "invalid.illegal.character.string.paket"
+            }
+          ]
+        }
+      ]
+    },
+    "line-comments": {
+      "patterns": [
+        {
+          "match": "//.*$",
+          "name": "comment.line.double-slash.fsharp"
+        },
+        {
+          "match": "#.*$",
+          "name": "comment.line.sharp.paket"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "match": "\\b[0-9]+\\.[0-9]+(\\.[0-9]+(\\.[0-9]+)?)?(-[.0-9A-Za-z-]+)?(\\+[.0-9A-Za-z-]+)?\\b",
+          "name": "constant.numeric.version-number.paket"
+        },
+        {
+          "match": "\\b(-?((0(x|X)[0-9a-fA-F][0-9a-fA-F_]*)|(0(o|O)[0-7][0-7_]*)|(0(b|B)[01][01_]*)|([0-9][0-9_]*)))\\b",
+          "name": "constant.numeric.integer.nativeint.paket"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "match": "\\b(source|github|nuget|gist|http|group|strategy|framework|references|content|copy_content_to_output_dir|import_targets|copy_local|redirects|lowest_matching|version_in_path|prerelease)\\b",
+          "name": "keyword.other.fsharp"
+        },
+        {
+          "match": "(~>|>=|<=|=|<|>)",
+          "name": "keyword.operator.paket"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "begin": "(?=[^\\\\])(\")",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.begin.paket"
+            }
+          },
+          "end": "(\")",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.end.paket"
+            }
+          },
+          "name": "string.quoted.double.paket",
+          "patterns": [
+            {
+              "match": "\\\\$[ \\t]*",
+              "name": "punctuation.separator.string.ignore-eol.paket"
+            },
+            {
+              "match": "\\\\([\\\\'ntbr]|u[a-fA-F0-9]{4}|u[a-fA-F0-9]{8})",
+              "name": "constant.character.string.escape.paket"
+            },
+            {
+              "match": "\\\\(?![\\\\'ntbr]|u[a-fA-F0-9]{4}|u[a-fA-F0-9]{8}).",
+              "name": "invalid.illeagal.character.string.paket"
+            }
+          ]
+        },
+        {
+          "match": "\\b(http|https)://[^ ]*\\b",
+          "name": "string.url.paket"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.paket.dependencies"
+}

--- a/paket.lock.json
+++ b/paket.lock.json
@@ -1,0 +1,134 @@
+{
+  "fileTypes": [
+    "paket.lock"
+  ],
+  "foldingStartMarker": "",
+  "foldingStopMarker": "",
+  "name": "Paket",
+  "patterns": [
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#line-comments"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#definition"
+    },
+    {
+      "include": "#keywords"
+    }
+  ],
+  "repository": {
+    "characters": {
+      "patterns": [
+        {
+          "begin": "(')",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.begin.paket"
+            }
+          },
+          "end": "(')",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.end.paket"
+            }
+          },
+          "name": "string.quoted.single.paket",
+          "patterns": [
+            {
+              "match": "\\\\$[ \\t]*",
+              "name": "punctuation.separator.string.ignore-eol.paket"
+            },
+            {
+              "match": "\\\\([\\\\\"\"ntbr]|u[a-fA-F0-9]{4}|u[a-fA-F0-9]{8})",
+              "name": "constant.character.string.escape.paket"
+            },
+            {
+              "match": "\\\\(?![\\\\'ntbr]|u[a-fA-F0-9]{4}|u[a-fA-F0-9]{8}).",
+              "name": "invalid.illegal.character.string.paket"
+            }
+          ]
+        }
+      ]
+    },
+    "line-comments": {
+      "patterns": [
+        {
+          "match": "//.*$",
+          "name": "comment.line.double-slash.fsharp"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "match": "\\b[0-9]+\\.[0-9]+(\\.[0-9]+(\\.[0-9]+)?)?(-[.0-9A-Za-z-]+)?(\\+[.0-9A-Za-z-]+)?\\b",
+          "name": "constant.numeric.version-number.paket"
+        },
+        {
+          "match": "\\b(-?((0(x|X)[0-9a-fA-F][0-9a-fA-F_]*)|(0(o|O)[0-7][0-7_]*)|(0(b|B)[01][01_]*)|([0-9][0-9_]*)))\\b",
+          "name": "constant.numeric.integer.nativeint.paket"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "match": "\\b(GITHUB|NUGET|GIST|HTTP|GROUP|specs|remote)\\b",
+          "name": "keyword.other.fsharp"
+        },
+        {
+          "match": "\\b(framework|import_targets|content|redirects)\\b",
+          "name": "keyword.other.fsharp"
+        },
+        {
+          "match": "(~>|>=|<=|=|<|>)",
+          "name": "keyword.operator.paket"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "begin": "(?=[^\\\\])(\")",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.begin.paket"
+            }
+          },
+          "end": "(\")",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.end.paket"
+            }
+          },
+          "name": "string.quoted.double.paket",
+          "patterns": [
+            {
+              "match": "\\\\$[ \\t]*",
+              "name": "punctuation.separator.string.ignore-eol.paket"
+            },
+            {
+              "match": "\\\\([\\\\'ntbr]|u[a-fA-F0-9]{4}|u[a-fA-F0-9]{8})",
+              "name": "constant.character.string.escape.paket"
+            },
+            {
+              "match": "\\\\(?![\\\\'ntbr]|u[a-fA-F0-9]{4}|u[a-fA-F0-9]{8}).",
+              "name": "invalid.illeagal.character.string.paket"
+            }
+          ]
+        },
+        {
+          "match": "\\b(http|https)://[^ ]*\\b",
+          "name": "string.url.paket"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.paket.lock"
+}


### PR DESCRIPTION
This PR is a port of https://github.com/ionide/ionide-paket/pull/39 to the `ionide-fsgrammar` repository as suggested in PR comments.

-----

The grammars were ported from the cson version that is present in the ionide-paket repository for Atom.
The target is to be able to share them between Atom and vscode plugins.

Changes done in addition to the conversion:
 - Used a more specific 'fileTypes' extension ('lock' -> 'paket.lock')
 - 'scopeName' changed to be different between lock and dependencies
   grammars (vscode replace one with the other if they share a root
   scopeName)