### PR TITLE
Enhanced Record type syntax highlighting

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -470,7 +470,7 @@
             "patterns": [
                 {
                     "name": "record.fsharp",
-                    "match": "(type)[\\s]+(private|internal|public)?[\\s]*([a-zA-Z0-9'<>^:,. ]+)((with)|(=)|(\\(\\)))",
+                    "match": "(type)[\\s]+(private|internal|public)?[\\s]*([a-zA-Z0-9'<>^:,. ]+)[\\s]*(\\([a-zA-Z0-9'\\:]+\\))?[\\s]*((with)|(as [a-zA-Z0-9']+)|(=)|(\\(\\)))",
 
                     "captures": {
                         "1": {
@@ -482,13 +482,19 @@
                         "3": {
                             "name": "entity.name.type.fsharp"
                         },
-                        "5": {
-                            "name": "keyword.other.fsharp"
+                        "4":{
+                            "name": "entity.name.type.fsharp"
                         },
                         "6": {
                             "name": "keyword.other.fsharp"
                         },
                         "7": {
+                            "name": "keyword.other.fsharp"
+                        },
+                        "8": {
+                            "name": "keyword.other.fsharp"
+                        },
+                        "9": {
                             "name": "constant.language.unit.fsharp"
                         }
                     }

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -15,4 +15,9 @@ type Class1() =
     member this.X = "F#"
 
 
+type FancyClass(thing:int) as xxx =
+
+    let pf() = xxx.Test()
+
+    member xxx.Test() = "F#"
 


### PR DESCRIPTION
Original syntax supported only basic type declarations with visibility and empty constructors.  The new one handles constructor parameters (though simply) and self reference renames.