### PR TITLE
Further changes to type declaration syntax highlighting

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -470,7 +470,7 @@
             "patterns": [
                 {
                     "name": "record.fsharp",
-                    "match": "(type)[\\s]+(private|internal|public)?[\\s]*([a-zA-Z0-9'<>^:,. ]+)((with)|(=)|(\\(\\)))",
+                    "match": "(type)[\\s]+(private|internal|public)?[\\s]*([a-zA-Z0-9'<>^:,. ]+)[\\s]*(\\([a-zA-Z0-9'\\:]+\\))?[\\s]*((with)|(as [a-zA-Z0-9']+)|(=)|(\\(\\)))",
 
                     "captures": {
                         "1": {
@@ -482,13 +482,19 @@
                         "3": {
                             "name": "entity.name.type.fsharp"
                         },
-                        "5": {
-                            "name": "keyword.other.fsharp"
+                        "4":{
+                            "name": "entity.name.type.fsharp"
                         },
                         "6": {
                             "name": "keyword.other.fsharp"
                         },
                         "7": {
+                            "name": "keyword.other.fsharp"
+                        },
+                        "8": {
+                            "name": "keyword.other.fsharp"
+                        },
+                        "9": {
                             "name": "constant.language.unit.fsharp"
                         }
                     }

--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -470,7 +470,7 @@
             "patterns": [
                 {
                     "name": "record.fsharp",
-                    "match": "(type)[\\s]+(private|internal|public)?[\\s]*([a-zA-Z0-9'<>^:,. ]+)[\\s]*(\\([a-zA-Z0-9'\\:]+\\))?[\\s]*((with)|(as [a-zA-Z0-9']+)|(=)|(\\(\\)))",
+                    "match": "(type)[\\s]+(private|internal|public)?[\\s]*([a-zA-Z0-9'<>^:,. ]+)[\\s]*(\\([a-zA-Z0-9'<>^:,. ]+\\))?[\\s]*((with)|(as [a-zA-Z0-9']+)|(=)|(\\(\\)))",
 
                     "captures": {
                         "1": {

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -15,4 +15,9 @@ type Class1() =
     member this.X = "F#"
 
 
+type FancyClass(thing:int) as xxx =
+
+    let pf() = xxx.Test()
+
+    member xxx.Test() = "F#"
 


### PR DESCRIPTION
Previous PR I generated for the syntax regex for a type declaration failed to handled certain types of parameters, specifically qualified names (Module.Type) and generics <>.  This should fix that.