### PR TITLE
Fix syntaxic colorization for non-ascii characters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 [Visual Studio Code is required to use FSharp.SyntaxTest](https://code.visualstudio.com/download)
 
 FSharp.SyntaxTest is a lightweight extension that allows for fast testing of modifications to the
-syntax definiton files located in `/grammar/` 
+syntax definiton files located in `/grammar/`
 
 Open VSCode at the repository root and use either `F5` or `> Start Debugging` to start the extension host
 which will open at `/sample-code/`
@@ -11,13 +11,16 @@ which will open at `/sample-code/`
 
 
 ## Important Notes
-  
+
 - Only modifications made to the syntax files in `/grammar/` will be tracked by Git
 - If you're going to add more src files to `/sample-code/` remember to add the files to `SampleCode.fsproj`
 - You may need to close and restart the extension host before changes to the syntax definitions are accurately displayed
 - [Reference the F# Language Spec for detail on the syntax grammar](http://fsharp.org/specs/language-spec/4.0/FSharpSpec-4.0-latest.pdf#page=320)
-  
 
+
+## Grammar format
+
+VSCode language colorization is based on TextMate language specifications, which use the [Oniguruma regular expression library by K. Kosako](https://github.com/kkos/oniguruma). A reference for Oniguruma is availaible on the [TextMate manual](https://manual.macromates.com/en/regular_expressions).
 
 ## Roadmap
 
@@ -26,4 +29,4 @@ for more in-depth information about which tokens are being created
 - Add Syntax Grammar for [FsYacc](https://github.com/fsprojects/FsLexYacc)
 - Support XML syntax highlighting in documentation `///` comments?
 - Support Markdown syntax highlighting in documentation and block `(* *)` comments?
- 
+

--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -140,7 +140,7 @@
             "patterns": [
                 {
                     "name": "binding.fsharp",
-                    "begin": "\\b(val mutable|val|let mutable|let inline|let|member|static member|override|let!)(\\s+rec|mutable)?(\\s+private|internal|public)?\\s+(\\([^\\s-]*\\)|[_a-zA-Z]([_a-zA-Z0-9,\\.]|(?<=,)\\s)*)",
+                    "begin": "\\b(val mutable|val|let mutable|let inline|let|member|static member|override|let!)(\\s+rec|mutable)?(\\s+private|internal|public)?\\s+(\\([^\\s-]*\\)|[_[:alpha:]]([_[:alpha:]0-9,\\.]|(?<=,)\\s)*)",
                     "end": "((``.*``)|(with)|=|$)",
                     "beginCaptures": {
                         "1": {
@@ -196,7 +196,7 @@
             "patterns": [
                 {
                     "name": "entity.name.section.fsharp",
-                    "begin": "\\b(namespace|module)(\\s+public|internal|private)?\\s+([a-zA-Z][a-zA-Z0-9'_. ]*)",
+                    "begin": "\\b(namespace|module)(\\s+public|internal|private)?\\s+([[:alpha:]][[:alpha:]0-9'_. ]*)",
                     "end": "(\\s|$)",
                     "beginCaptures": {
                         "1": {
@@ -212,7 +212,7 @@
                     "patterns": [
                         {
                             "name": "entity.name.section.fsharp",
-                            "match": "(\\.)([A-Z][a-zA-Z0-9'_]*)",
+                            "match": "(\\.)([A-Z][[:alpha:]0-9'_]*)",
                             "captures": {
                                 "1": {
                                     "name": "punctuation.separator.namespace-reference.fsharp"
@@ -226,7 +226,7 @@
                 },
                 {
                     "name": "namespace.open.fsharp",
-                    "begin": "\\b(open)\\s+([a-zA-Z][a-zA-Z0-9'_]*)(?=(\\.[A-Z][a-zA-Z0-9_]*)*)",
+                    "begin": "\\b(open)\\s+([[:alpha:]][[:alpha:]0-9'_]*)(?=(\\.[A-Z][[:alpha:]0-9_]*)*)",
                     "end": "(\\s|$)",
                     "beginCaptures": {
                         "1": {
@@ -239,7 +239,7 @@
                     "patterns": [
                         {
                             "name": "entity.name.section.fsharp",
-                            "match": "(\\.)([a-zA-Z][a-zA-Z0-9'_]*)",
+                            "match": "(\\.)([[:alpha:]][[:alpha:]0-9'_]*)",
                             "captures": {
                                 "1": {
                                     "name": "punctuation.separator.namespace-reference.fsharp"
@@ -253,7 +253,7 @@
                 },
                 {
                     "name": "namespace.alias.fsharp",
-                    "begin": "^\\s*(module)\\s+([A-Z][a-zA-Z0-9'_]*)\\s*(=)\\s*([A-Z][a-zA-Z0-9'_]*)",
+                    "begin": "^\\s*(module)\\s+([A-Z][[:alpha:]0-9'_]*)\\s*(=)\\s*([A-Z][[:alpha:]0-9'_]*)",
                     "end": "(\\s|$)",
                     "beginCaptures": {
                         "1": {
@@ -272,7 +272,7 @@
                     "patterns": [
                         {
                             "name": "entity.name.section.fsharp",
-                            "match": "(\\.)([A-Z][a-zA-Z0-9'_]*)",
+                            "match": "(\\.)([A-Z][[:alpha:]0-9'_]*)",
                             "captures": {
                                 "1": {
                                     "name": "punctuation.separator.namespace-reference.fsharp"
@@ -443,7 +443,7 @@
                 },
                 {
                     "name": "variable.parameter.fsharp",
-                    "match": "[a-zA-Z']\\w*"
+                    "match": "[[:alpha:]']\\w*"
                 }
             ]
         },
@@ -470,7 +470,7 @@
             "patterns": [
                 {
                     "name": "record.fsharp",
-                    "match": "(type)[\\s]+(private|internal|public)?[\\s]*([a-zA-Z0-9'<>^:,. ]+)[\\s]*(\\([a-zA-Z0-9'<>^:,. ]+\\))?[\\s]*((with)|(as [a-zA-Z0-9']+)|(=)|(\\(\\)))",
+                    "match": "(type)[\\s]+(private|internal|public)?[\\s]*([[:alpha:]0-9'<>^:,. ]+)[\\s]*(\\([[:alpha:]0-9'<>^:,. ]+\\))?[\\s]*((with)|(as [[:alpha:]0-9']+)|(=)|(\\(\\)))",
 
                     "captures": {
                         "1": {
@@ -505,7 +505,7 @@
             "patterns": [
                 {
                     "name": "cexpr.fsharp",
-                    "match": "\\b([a-zA-Z]*\\s+\\{)",
+                    "match": "\\b([[:alpha:]]*\\s+\\{)",
                     "captures": {
                         "1": {
                             "name": "keyword.other.fsharp"

--- a/sample-code/SimpleBindings.fs
+++ b/sample-code/SimpleBindings.fs
@@ -10,7 +10,7 @@ let c_byte       = 'F'B
 
 let a_int16      = 44s
 let a_uint16     = 44us
-let a_int        = 100 
+let a_int        = 100
 let a_int32      = 100l
 let a_uint       = 100u
 let a_uin32      = 100ul
@@ -29,8 +29,8 @@ let h_float32    = 180.3E+32F
 let i_float32    = 180.4e+10F
 
 let a_float64    = 30.0
-let b_float64    = 40.0e5 
-let c_float64    = 2.3E+32  
+let b_float64    = 40.0e5
+let c_float64    = 2.3E+32
 let d_float64    = 2.3e+32
 let e_float64    = 0x0000000000000000LF
 
@@ -39,6 +39,7 @@ let a_bigint     = 304554I
 
 let binding = "empty"
 let aString : string = "typed"
+let accentué = "accentué"
 
 let tupA1, tupA2 = 1, 2
 let (tupB1, tupB2) : decimal * decimal = 40m, 50M

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -10,6 +10,8 @@ type LightDU =
 
 type Underscore_Name = | Underscore_Name of string
 
+type Accentué = int
+
 
 type Class1() =
     member this.X = "F#"
@@ -22,6 +24,9 @@ type FancyClass(thing:int) as xxx =
     member xxx.Test() = "F#"
 
 module test =
+    let t = 1
+
+module accentué =
     let t = 1
 
 open test


### PR DESCRIPTION
Non-ASCII characters like french "é, è" where breaking syntaxic colorization.