### PR TITLE
Improve bindings detections

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -141,7 +141,7 @@
             "patterns": [
                 {
                     "name": "binding.fsharp",
-                    "begin": "\\b(val mutable|val|let mutable|let inline|let|member|static member|override|let!)(\\s+rec|mutable)?(\\s+\\[\\<.*\\>\\])?\\s*(private|internal|public)?\\s+(\\([^\\s-]*\\)|[_[:alpha:]]([_[:alpha:]0-9,\\._]|(?<=,)\\s)*)",
+                    "begin": "\\b(val mutable|val|let mutable|let inline|let|member|static member|override|let!)(\\s+rec|mutable)?(\\s+\\[\\<.*\\>\\])?\\s*(private|internal|public)?\\s+(\\([^-]*\\)|\\[[^-=]*\\]|[_[:alpha:]]([_[:alpha:]0-9,\\._]|(?<=,)\\s)*|``[_[:alpha:]]([_[:alpha:]0-9,\\._`\\s]|(?<=,)\\s)*)",
                     "end": "((``.*``)|(with)|=|$)",
                     "beginCaptures": {
                         "1": {

--- a/sample-code/SimpleBindings.fs
+++ b/sample-code/SimpleBindings.fs
@@ -53,6 +53,7 @@ printfn "\s"
 sprintf ""
 
 let tupA1, tupA2 = 1, 2
+let (tupB1,tupB2) : decimal * decimal = 40m, 50M
 let (tupB1, tupB2) : decimal * decimal = 40m, 50M
 let [| a; b |] = [| 1; 2 |]
 let [ c; d ] = [1; 2]
@@ -60,6 +61,10 @@ let ``tick`` = ""
 let ``tick with mutiple words`` = ""
 let quote' = ""
 let multiple'quote = ""
+
+type T = C of int
+let m = C 3
+let (C n) = C 3
 
 let x = fun a -> 17
 

--- a/sample-code/SimpleBindings.fs
+++ b/sample-code/SimpleBindings.fs
@@ -56,8 +56,10 @@ let tupA1, tupA2 = 1, 2
 let (tupB1, tupB2) : decimal * decimal = 40m, 50M
 let [| a; b |] = [| 1; 2 |]
 let [ c; d ] = [1; 2]
-let ``test`` = ""
-let ``test mutiple words`` = ""
+let ``tick`` = ""
+let ``tick with mutiple words`` = ""
+let quote' = ""
+let multiple'quote = ""
 
 let x = fun a -> 17
 

--- a/sample-code/SimpleBindings.fs
+++ b/sample-code/SimpleBindings.fs
@@ -54,6 +54,10 @@ sprintf ""
 
 let tupA1, tupA2 = 1, 2
 let (tupB1, tupB2) : decimal * decimal = 40m, 50M
+let [| a; b |] = [| 1; 2 |]
+let [ c; d ] = [1; 2]
+let ``test`` = ""
+let ``test mutiple words`` = ""
 
 let x = fun a -> 17
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4760796/29459082-6bf18ad8-8422-11e7-84b2-b02b650de380.png)

After:
![image](https://user-images.githubusercontent.com/4760796/29459098-757cd8d2-8422-11e7-94ed-a17a511f99ca.png)

------------

Here is the list of the change made into the regex:

- Allow space between parentheses
  - New group: `(\\([^-]*\\)`
  - Old group: (\\([^\\s-]*\\)
- Allow brackets captures:
  - ` \\[[^-=]*\\] ` I needed to exclude the `=` to avoid capturing the whole line (on single line). See how the colors are wrong after the `=`
![image](https://user-images.githubusercontent.com/4760796/29459238-0f76ca42-8423-11e7-960e-22e7fd885ed5.png)
- Detect double ticked names (spaces allowed):
  - ` ``[_[:alpha:]]([_[:alpha:]0-9,\\._`\\s]|(?<=,)\\s)*) `

-------------

I am still trying to understand how the grammar works so we could probably improve colors for brackets, parentheses and double tick. If you have any idea on how to archieve this goal this would be nice :)