### PR TITLE
added format specifier to string

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -326,7 +326,12 @@
                         "1": {
                             "name": "punctuation.definition.string.end.fsharp"
                         }
-                    }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#string_formatter"
+                        }
+                    ]
                 },
                 {
                     "name": "string.quoted.double.fsharp",
@@ -354,8 +359,24 @@
                         {
                             "name": "invalid.illeagal.character.string.fsharp",
                             "match": "\\\\(?![\\\\''ntbr]|u[a-fA-F0-9]{4}|u[a-fA-F0-9]{8})."
+                        },                        
+                        {
+                            "include": "#string_formatter"
                         }
                     ]
+                }
+            ]
+        },
+        "string_formatter": {
+            "patterns": [
+                {
+                    "name": "entity.name.type.format.specifier.fsharp",
+                    "match": "(%0?-?(\\d+)?((a|t)|(\\.\\d+)?(f|F|e|E|g|G|M)|(b|c|s|d|i|x|X|o)|(s|b|O)|(\\+?A)))",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.other.format.specifier.fsharp"
+                        }                     
+                    }
                 }
             ]
         },

--- a/sample-code/SimpleBindings.fs
+++ b/sample-code/SimpleBindings.fs
@@ -51,6 +51,24 @@ let literal_test2 = 11
 printf  "\d"
 printfn "\s"
 sprintf ""
+printf "some tup %A dasda" ((2),2)
+printf "%O" (1,2,3)
+printf "%s" ""
+printf "%E" 2.0
+printf "%1e" 1.0
+printf "sss  %-1e" 2.
+printf "%-10s" "2"
+printf "%020.1f" 0.2f
+
+sprintf "75.9%% ss"
+sprintf """
+dfdfdf %s
+"""
+
+let numbers = [ 1 .. 10 ]
+let square x = x * x
+let squares = List.map square numbers
+printfn "N^2 = %A" squares
 
 let tupA1, tupA2 = 1, 2
 let (tupB1,tupB2) : decimal * decimal = 40m, 50M


### PR DESCRIPTION
before 
![before](https://user-images.githubusercontent.com/4703715/31523283-d5a8590a-afb2-11e7-96c2-d2a2bd70dba8.png)
after
![after](https://user-images.githubusercontent.com/4703715/31523282-d5731bfa-afb2-11e7-8118-eeb715e74730.png)

------------------
Docs for the format specification:
https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/core.printf-module-%5Bfsharp%5D

- Main purpose is to make it easier to spot the format specifiers in the strings.
- added to double and tripple quoted strings
I'm fairly new to TextMate grammers and not completely sure if I have selected the right names for the scopes.

