### PR TITLE
Fix the `type` coloring when the `=` is on a different line

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -415,7 +415,7 @@
             "patterns": [
                 {
                     "name": "record.fsharp",
-                    "match": "(type)[\\s]+(private|internal|public)?[\\s]*([[:alpha:]0-9'<>^:,._]+)[\\s]*(\\([[:alpha:]0-9'<>^:,._ ]+\\))?[\\s]*((with)|(as [[:alpha:]0-9']+)|(=)|(\\(\\)))",
+                    "match": "(type)[\\s]+(private|internal|public)?[\\s]*([[:alpha:]0-9'<>^:,._]+)[\\s]*(\\([[:alpha:]0-9'<>^:,._ ]+\\))?[\\s]*((with)|(as [[:alpha:]0-9']+)|(\\(\\)))",
 
                     "captures": {
                         "1": {


### PR DESCRIPTION
Fix the coloring when the `=` is on a different line for a `type`, example:
```
type Something
    = SomethingElse
    | SomethingDifferent
```
