### PR TITLE
Fix #43: Accessibility modifier coloring inconsistent between record and union types

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -183,7 +183,7 @@
             "patterns": [
                 {
                     "name": "keyword.other.fsharp",
-                    "match": "\\b(function|yield!|yield|class|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|property|union|enum|member|try|finally|and|when|use|use\\!|struct|while|mutable)(?!')\\b"
+                    "match": "\\b(private|public|internal|function|yield!|yield|class|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|property|union|enum|member|try|finally|and|when|use|use\\!|struct|while|mutable)(?!')\\b"
                 },
                 {
                     "name": "meta.preprocessor.fsharp",

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -19,6 +19,9 @@ type Accentué = int
 type Class1() =
     member this.X = "F#"
 
+// Check accessibility modifier coloring
+type R = private { X  : int }
+type U = private | X of int
 
 type FancyClass(thing:int, var2 : string) as xxx =
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/4760796/40515409-f716d454-5fac-11e8-9d35-0fcc32cba7a8.png)


Now:

![image](https://user-images.githubusercontent.com/4760796/40515387-e2bac380-5fac-11e8-8509-19086a06faa6.png)

I have one difference with the screenshots from  https://github.com/ionide/ionide-fsgrammar/issues/43
My `{` are white where the `|` is purple this is due to a rainbow brackets extension I am using. So please ignore this difference :)