### PR TITLE
Fix #32: Wrong method call coloring

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -453,9 +453,9 @@
             "patterns": [
                 {
                     "name": "cexpr.fsharp",
-                    "match": "\\b([[:alpha:]]*\\s+\\{)",
+                    "match": "\\b((?:[[:alpha:]]+\\.[[:alpha:]]+)|([[:alpha:]]+))\\s+\\{",
                     "captures": {
-                        "1": {
+                        "2": {
                             "name": "keyword.other.fsharp"
                         }
                     }

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -60,3 +60,11 @@ let test2 return' =
     match return' with
     | CaseA -> ""
     | CaseB -> ""
+
+type RequestData =
+    { Params : string }
+
+type Client () =
+    member this.Request (req : RequestData) = ""
+
+let res (client : Client) = client.Request { Params = "" }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/4760796/40517229-6fb9f740-5fb4-11e8-955c-925c2cc725bf.png)

Now:

![image](https://user-images.githubusercontent.com/4760796/40517219-60600456-5fb4-11e8-93ee-2247000df693.png)

## Samples and results

- `client.Request {` => text is white
- `a.long.module.path.client.Request {` => text is white
- `singleWord {` => text is purple

I don't think we can fix the case 3 because we need it to support comprehension expression (if the term is correct) like `promise`, `async`, etc.