### PR TITLE
Fix for ionide/ionide-vscode-fsharp#828

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -133,7 +133,7 @@
                 {
                     "name": "comment.line.markdown.fsharp",
                     "begin": "///",
-                    "end": "$",
+                    "while": "///",
                     "patterns": [
                         {
                             "include": "text.html.markdown"

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -18,6 +18,10 @@ module SampleCode.SimpleTypes
 let markdownDemo (arg1 : string) (arg2 : string) =
     ""
 
+/// **Checking that markdown is really working on single line**
+let markdownDemo2 (arg1 : string) (arg2 : string) =
+    ""
+
 // **This comment isn't formatted**
 
 (* Neither this one *)


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/4760796/40561302-f5a74ec2-605c-11e8-8e2f-1ee17d9c556d.png)

Now:

![image](https://user-images.githubusercontent.com/4760796/40561316-029460de-605d-11e8-929b-13bb5af864b7.png)
