### PR TITLE
Fix edge cases of the markdown highlight

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -97,8 +97,8 @@
             "patterns": [
                 {
                     "name": "comment.block.markdown.fsharp",
-                    "begin": "(\\(\\*\\*(?!\\)))",
-                    "end": "(\\*\\))",
+                    "begin": "^\\s*(\\(\\*\\*(?!\\)))(?!\\*\\))$",
+                    "while": "^(?!\\s*\\*\\)$)",
                     "beginCaptures": {
                         "1": {
                             "name": "comment.block.fsharp"
@@ -114,6 +114,15 @@
                             "include": "text.html.markdown"
                         }
                     ]
+                },
+                {
+                    "name": "comment.block.markdown.fsharp.end",
+                    "match": "^(\\s*\\*\\)$)",
+                    "captures": {
+                        "1": {
+                            "name": "comment.block.fsharp"
+                        }
+                    }
                 },
                 {
                     "name": "comment.block.fsharp",

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -4,6 +4,28 @@ Some more documentation using `Markdown`.
 *)
 module SampleCode.SimpleTypes
 
+module Test =
+
+    (** **Check** that this line isn't capture for the markdown grammar *)
+    let a = ""
+
+    (**
+    This is an edge case, because in early implementation this is commented the whilte file
+
+    Line with indentation isn't colorized because markdown can't set up his context.
+    *)
+    let b = ""
+
+    (**
+This block is colorized becasue markdown can set up his context.
+
+# First-level heading
+This should be parsed as `markdown`.
+This is an edge case, because in early implementation this is parser the whole
+file as markdown
+    *)
+    let c = ""
+
 /// **Description**
 ///
 /// **Parameters**


### PR DESCRIPTION
Related to: https://github.com/ionide/ionide-vscode-fsharp/issues/828#issuecomment-392193652

Before:

![image](https://user-images.githubusercontent.com/4760796/40574039-62ac9aa4-60cb-11e8-9949-f72adec5bd80.png)

Now:

![image](https://user-images.githubusercontent.com/4760796/40574044-74bbfeb0-60cb-11e8-989f-3cf2a3b692a5.png)
