### PR TITLE
Add support for DU declaration + Small fix in member declaration

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -28,7 +28,7 @@
         {
             "include": "#definition"
         },
-         {
+        {
             "include": "#attributes"
         },
         {
@@ -39,6 +39,9 @@
         },
         {
             "include": "#anonymous_functions"
+        },
+        {
+            "include": "#du_declaration"
         },
         {
             "include": "#keywords"
@@ -215,6 +218,47 @@
                         },
                         {
                             "include": "#member_declaration"
+                        }
+                    ]
+                }
+            ]
+        },
+        "du_declaration": {
+            "patterns": [
+                {
+                    "name": "du_declaration.fsharp",
+                    "begin": "(of)",
+                    "end": "$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.other.fsharp"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "match": "([^:*]+)(:)([^:*]+)",
+                            "captures": {
+                                "1": {
+                                    "name": "variable.parameter.fsharp"
+                                },
+                                "2": {
+                                    "name": "keyword.other.fsharp"
+                                },
+                                "3": {
+                                    "name": "entity.name.type.fsharp"
+                                }
+                            }
+                        },
+                        {
+                            "match": "([^:*]+)",
+                            "captures": {
+                                "1": {
+                                    "name": "entity.name.type.fsharp"
+                                }
+                            }
+                        },
+                        {
+                            "include": "#keywords"
                         }
                     ]
                 }

--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -236,7 +236,7 @@
                     },
                     "patterns": [
                         {
-                            "match": "([^:*]+)(:)([^:*]+)",
+                            "match": "([[:alpha:]0-9'`<>^._][[:alpha:]0-9'`<>^._]+)(:)([[:alpha:]0-9'`<>^._]+)",
                             "captures": {
                                 "1": {
                                     "name": "variable.parameter.fsharp"
@@ -250,7 +250,17 @@
                             }
                         },
                         {
-                            "match": "([^:*]+)",
+                            "match": "([[:alpha:]0-9'`<>^._]+)",
+                            "captures": {
+                                "1": {
+                                    "name": "entity.name.type.fsharp"
+                                }
+                            }
+                        },
+                        {
+                            "begin": "\\(",
+                            "end": "\\)",
+                            "match": "([[:alpha:]0-9'`<>^._]+)",
                             "captures": {
                                 "1": {
                                     "name": "entity.name.type.fsharp"

--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -440,12 +440,15 @@
                     "end": "\\)",
                     "patterns": [
                         {
-                            "match": "\\?{0,1}([[:alpha:]0-9'`<>^._]+)\\s*(:{0,1}\\s*([?[:alpha:]0-9'<>^._]+)){0,1}",
+                            "match": "\\?{0,1}([[:alpha:]0-9'`<>^._]+)\\s*(:{0,1})(\\s*([?[:alpha:]0-9'<>^._]+)){0,1}",
                             "captures": {
                                 "1": {
                                     "name": "variable.parameter.fsharp"
                                 },
                                 "2": {
+                                    "name": "keyword.other.fsharp"
+                                },
+                                "3": {
                                     "name": "entity.name.type.fsharp"
                                 }
                             }

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -142,3 +142,5 @@ type TestDUTypeColoration =
     | CaseD of name :string * age:int
     | CaseE of client: Client
     | CaseF of client: Client * string * port : int
+    | CaseG of (obj -> unit)
+    | CaseH of string * (obj -> unit)

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -131,7 +131,14 @@ let res (client : Client, extraParam) = client.Request { Params = "" }
 [<Measure>]
 type kg
 
-
 let forLoop =
     [ for index = 0 to 1 do
-        yield "" ]
+        yield index ]
+
+type TestDUTypeColoration =
+    | CaseA
+    | CaseB of int
+    | CaseC of int * string
+    | CaseD of name :string * age:int
+    | CaseE of client: Client
+    | CaseF of client: Client * string * port : int


### PR DESCRIPTION
**In the next screen shot I am comparing current master branch and the branch from this PR as Ionide do not include the latest grammar.**

### Member declaration:

*The change is made to color the `:` symbol from gold to purple like others keywords*

Before:
<img width="492" alt="capture d ecran 2018-05-29 a 13 03 04" src="https://user-images.githubusercontent.com/4760796/40655446-b016898a-6341-11e8-8cc8-80c47c56ec58.png">

Now:
<img width="525" alt="capture d ecran 2018-05-29 a 13 02 06" src="https://user-images.githubusercontent.com/4760796/40655451-b2da28ac-6341-11e8-8e4b-ae9170f60f80.png">

### DU declaration:

*I think I have covered all the cases of DU declaration please tell me if I missed one*

Before:
<img width="415" alt="capture d ecran 2018-05-29 a 13 31 13" src="https://user-images.githubusercontent.com/4760796/40656428-9fd56200-6344-11e8-95d5-8d1242688cde.png">


Now:
<img width="364" alt="capture d ecran 2018-05-29 a 13 27 36" src="https://user-images.githubusercontent.com/4760796/40656436-a57088de-6344-11e8-8a84-eebe0505530c.png">

