### PR TITLE
Fix #51: Capture the leading { of CE for color

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -582,7 +582,7 @@
             "patterns": [
                 {
                     "name": "cexpr.fsharp",
-                    "match": "\\b(async|promise|task|maybe|asyncMaybe|controller|scope|application|pipeline)\\s+\\{",
+                    "match": "\\b(async|promise|task|maybe|asyncMaybe|controller|scope|application|pipeline\\s+\\{)",
                     "captures": {
                         "1": {
                             "name": "keyword.other.fsharp"


### PR DESCRIPTION
Before:
<img width="384" alt="capture d ecran 2018-05-29 a 16 02 27" src="https://user-images.githubusercontent.com/4760796/40663761-b6efbdd6-6359-11e8-8c7e-54114db5a75f.png">

Now:
<img width="364" alt="capture d ecran 2018-05-29 a 15 59 48" src="https://user-images.githubusercontent.com/4760796/40663766-b927e7c2-6359-11e8-8a3b-0936e2268e05.png">
