### PR TITLE
Fix CE builders

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -586,7 +586,7 @@
             "patterns": [
                 {
                     "name": "cexpr.fsharp",
-                    "match": "\\b(async|promise|task|maybe|asyncMaybe|controller|scope|application|pipeline)\\s*\\{",
+                    "match": "\\b(async|seq|promise|task|maybe|asyncMaybe|controller|scope|application|pipeline)\\s*\\{",
                     "captures": {
                         "0": {
                             "name": "keyword.other.fsharp"

--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -586,9 +586,9 @@
             "patterns": [
                 {
                     "name": "cexpr.fsharp",
-                    "match": "\\b(async|promise|task|maybe|asyncMaybe|controller|scope|application|pipeline\\s+\\{)",
+                    "match": "\\b(async|promise|task|maybe|asyncMaybe|controller|scope|application|pipeline)\\s*\\{",
                     "captures": {
-                        "1": {
+                        "0": {
                             "name": "keyword.other.fsharp"
                         }
                     }

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -76,6 +76,13 @@ let a = promise { }
 let b = pipeline { }
 let c = noColor { }
 
+// Check that known builder names aren't captured as builders when a
+// value name begins with one of them (e.g. `asyncResult`)
+// Also see ionide/ionide-vscode-fsharp#836
+let d =
+    let asyncF = async { }
+    asyncF
+
 type FancyClass(thing:int, var2 : string, ``ddzdz``: string list, extra) as xxx =
 
     let pf() = xxx.Test()

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -1,4 +1,4 @@
-﻿(**
+(**
 # First-level heading
 Some more documentation using `Markdown`.
 *)
@@ -82,6 +82,9 @@ let c = noColor { }
 let d =
     let asyncF = async { }
     asyncF
+
+// Whitespace between builder and opening brace is optional
+let e = async{ return 0 }
 
 type FancyClass(thing:int, var2 : string, ``ddzdz``: string list, extra) as xxx =
 


### PR DESCRIPTION
Fixes ionide/ionide-vscode-fsharp#836. This also adds `seq` CE builder to the list of known builders and fixes an illegal case (`foo6` in the screenshot).

Before:

![Screenshot - before](https://user-images.githubusercontent.com/11393003/40971276-62485540-68bd-11e8-8710-c856c91247ae.png)

After:

![Screenshot - after](https://user-images.githubusercontent.com/11393003/40971287-68c5a274-68bd-11e8-8ce7-d0fcd2451c8c.png)
