### PR TITLE
Add coloration support to output type of definition

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -217,6 +217,17 @@
                         },
                         {
                             "include": "#member_declaration"
+                        },
+                        {
+                            "match": "(:)(\\s*([?[:alpha:]0-9'<>^._ ]+))*",
+                            "captures" : {
+                                "1":  {
+                                    "name": "keyword.other.fsharp"
+                                },
+                                "2": {
+                                    "name": "entity.name.type.fsharp"
+                                }
+                            }
                         }
                     ]
                 }

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -100,6 +100,10 @@ let (name : string, age) = "", 0
 // Check that option is also colored as part of the type definition
 let debounce (debounce : int option) = ""
 
+// Check output type coloration
+let mutable timeoutID : float = 0.
+let test2 test (timeoutID : float option) : int option = None
+
 module test =
     let t = 1
 


### PR DESCRIPTION
Fix case n°2 #68 

Before:
<img width="473" alt="capture d ecran 2018-06-05 a 13 08 30" src="https://user-images.githubusercontent.com/4760796/40972753-08230984-68c2-11e8-85b1-4c3d82da460f.png">

Now:
<img width="490" alt="capture d ecran 2018-06-05 a 13 08 13" src="https://user-images.githubusercontent.com/4760796/40972751-061c33e0-68c2-11e8-9780-06274a8d94eb.png">
