### PR TITLE
Fix highlighting of 'of' in 'typeof' and 'typedefof'

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -237,7 +237,7 @@
             "patterns": [
                 {
                     "name": "du_declaration.fsharp",
-                    "begin": "(of)\\b",
+                    "begin": "\\b(of)\\b",
                     "end": "$|(\\|)",
                     "beginCaptures": {
                         "1": {

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -62,6 +62,9 @@ type EgalNewLine
 
 type Underscore_Name = | Underscore_Name of string
 
+let i32 = typeof<int>
+let list = typedefof<_ list>
+
 type Accentué = int
 
 type Class1() =


### PR DESCRIPTION
Fixes #74.

I hope this is correct.