### PR TITLE
Remove duplicate '>' char occurence from generic regex

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -63,7 +63,7 @@
         "generic_declaration": {
             "patterns": [
                 {
-                    "match": "([^<>,*()->])",
+                    "match": "([^<>,*()-])",
                     "captures": {
                         "1": {
                             "name": "entity.name.type.fsharp"
@@ -85,7 +85,7 @@
                     },
                     "patterns": [
                         {
-                            "match": "([^<>,*()->])",
+                            "match": "([^<>,*()-])",
                             "captures": {
                                 "1": {
                                     "name": "entity.name.type.fsharp"

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -156,7 +156,7 @@ type Decoder<'a> =
 
 let keyValuePairs (decoder : Decoder<'value>) : Decoder<(string * 'value) list> = failwith ""
 let keyValuePairs (decoder : Decoder<'value>) : Decoder<(string * 'value) list -> obj> = failwith ""
-
+let tuple2 (decoder1: Decoder<'T1>) (decoder2: Decoder<'T2>) : Decoder<'T1 * 'T2> = failwith ""
 
 let run (program : Program<'arg, 'model, 'msg, 'view>) = ""
 let run2 (program : unit -> Program<'arg, 'model, 'msg, 'view>) = ""


### PR DESCRIPTION
Fix #98

**Before**
<img width="651" alt="capture d ecran 2018-08-31 a 11 16 49" src="https://user-images.githubusercontent.com/4760796/44904514-cd94dd00-ad0f-11e8-83ed-60610d00761b.png">

**After**
<img width="652" alt="capture d ecran 2018-08-31 a 11 16 24" src="https://user-images.githubusercontent.com/4760796/44904518-cff73700-ad0f-11e8-850a-05a47aa4a390.png">
