### PR TITLE
Fix coloration between parenthesis

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -117,6 +117,9 @@
                     }
                 },
                 {
+                    "include": "#compiler_directives"
+                },
+                {
                     "include": "#constants"
                 },
                 {
@@ -130,6 +133,21 @@
                 },
                 {
                     "include": "#keywords"
+                },
+                {
+                    "include": "#text"
+                },
+                {
+                    "include": "#definition"
+                },
+                {
+                    "include": "#attributes"
+                },
+                {
+                    "include": "#keywords"
+                },
+                {
+                    "include": "#cexprs"
                 },
                 {
                     "include": "#text"

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -602,3 +602,12 @@ type MyClass =
     // new (a0, b0) = { a = a0; }
     // The following version is acceptable because all fields are initialized.
     new(a0, b0) = { a = a0; b = b0; }
+
+// Check that SRTP do not break standard syntax between `(` & `)`
+let incorrect =
+    (fun loadedModel ->
+        let temp = async {
+            return 0
+        }
+        let loadedModel = { loadedModel with FormState = Form.setWaiting false loadedModel.FormState }
+        ())


### PR DESCRIPTION
Related to https://github.com/ionide/ionide-vscode-fsharp/issues/961

Before:
<img width="801" alt="capture d ecran 2018-11-15 a 11 13 51" src="https://user-images.githubusercontent.com/4760796/48547339-aab7a500-e8ca-11e8-89c6-da0225b8641b.png">

After:
<img width="807" alt="capture d ecran 2018-11-15 a 11 13 56" src="https://user-images.githubusercontent.com/4760796/48547346-adb29580-e8ca-11e8-9850-b854a6c844d2.png">
