### PR TITLE
Fix coloration for get/set when naming tuples in abstract

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -597,7 +597,7 @@
                     "include": "#common_declaration"
                 },
                 {
-                    "match": "(\\?{0,1})([[:alpha:]0-9'`^._ ]+)\\s*(:)(\\s*([[:alpha:]0-9'`^._ ]+)){0,1}",
+                    "match": "(\\?{0,1})([[:alpha:]0-9'`^._ ]+)\\s*(:)((?!with\\b)\\b([\\w0-9'`^._ ]+)){0,1}",
                     "captures": {
                         "1": {
                             "name": "keyword.symbol.fsharp"

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -172,6 +172,7 @@ let run2 (program : unit -> Program<'arg, 'model, 'msg, 'view>) = ""
 
 type T =
     abstract Item: selector: string -> string with get, set
+    abstract icon: width : int * height : int with get, set
     abstract member Name: string option with get, set
     abstract member NameTestComment: string (*I am a comments*) option with get, set
     abstract member NameTestComment2: string //option with get, set


### PR DESCRIPTION
Fix #116

**Before**
<img width="507" alt="Capture d’écran 2019-04-16 à 14 12 17" src="https://user-images.githubusercontent.com/4760796/56208667-f3c67d80-6051-11e9-8cc1-802046a324c6.png">

**After**
<img width="502" alt="Capture d’écran 2019-04-16 à 14 12 21" src="https://user-images.githubusercontent.com/4760796/56208672-f628d780-6051-11e9-8e63-5e3c92ed9b5a.png">
