### PR TITLE
Fix Tuple invalid highlights if a type info is after generic scope

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -841,6 +841,14 @@
                     "include": "#definition"
                 },
                 {
+                    "match": "(?<=>)\\s*(``([[:alpha:]0-9'^._ ]+)``|[[:alpha:]0-9'`^._]+)",
+                    "captures": {
+                        "1": {
+                            "name": "entity.name.type.fsharp"
+                        }
+                    }
+                },
+                {
                     "include": "#variables"
                 },
                 {
@@ -966,7 +974,7 @@
                             }
                         },
                         {
-                            "match": "([[:alpha:]0-9'`^._]+)|``([[:alpha:]0-9'^._ ]+)``",
+                            "match": "(``([[:alpha:]0-9'^._ ]+)``|[[:alpha:]0-9'`^._]+)",
                             "captures": {
                                 "1": {
                                     "name": "entity.name.type.fsharp"

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -144,7 +144,8 @@ type FancyClass(thing:int, var2 : string -> string, ``ddzdz``: string list, extr
 
 let inline internal (<) (x : int) ys = x + ys
 let (< ) (x : int) ys = x + ys
-
+let inline internal (<==) (x : int) ys = x + ys
+let inline internal (<==) x ys = x + ys
 
 // Arrow should be colored as a keyword and int as type definition
 let exec (buildOptions: int -> int -> int -> int) args = ""
@@ -244,6 +245,8 @@ let listOfTuples
 let generics : Result<string list, int array> = Ok []
 
 let tupleWithGenerics : Result<string list, int array> * int = Ok [], 0
+let tupleWithAListOfGenerics : int * Map<int, int> list = 1, []
+let tupleWithAListOrArrayOfGenerics2 : int * Map<int, int> list * Map<int, int> array = 1, [], [||]
 
 // Really complexe nested generic type
 let tupleWithGenerics2 : (Result<Result<Result<Result<string, string>, string>, string> list, int array> * int) = Ok [], 0


### PR DESCRIPTION
Fix #119

**Before**
<img width="847" alt="Capture d’écran 2019-04-16 à 16 13 05" src="https://user-images.githubusercontent.com/4760796/56217056-da79fd00-6062-11e9-9b07-dc0eb142ac13.png">

**After**
<img width="745" alt="Capture d’écran 2019-04-16 à 16 13 12" src="https://user-images.githubusercontent.com/4760796/56217064-dc43c080-6062-11e9-9664-d9ffe8d88469.png">
