### PR TITLE
Fix let (<<.) breaks syntax higlight

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -798,7 +798,7 @@
                     }
                 },
                 {
-                    "begin": "(<(?![[:space:]]*\\)))",
+                    "begin": "(<+(?![[:space:]]*\\)))",
                     "beginComment": "The group (?![[:space:]]*\\) is for protection against overload operator. static member (<)",
                     "end": "((?<!:)>|\\))",
                     "endComment": "The group (?<!:) prevent us from stopping on :> when using SRTP synthax",

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -144,7 +144,7 @@ type FancyClass(thing:int, var2 : string -> string, ``ddzdz``: string list, extr
 
 let inline internal (<) (x : int) ys = x + ys
 let (< ) (x : int) ys = x + ys
-
+let (<<.) a = 1
 
 // Arrow should be colored as a keyword and int as type definition
 let exec (buildOptions: int -> int -> int -> int) args = ""


### PR DESCRIPTION
Fix #117

**Before**
<img width="515" alt="Capture d’écran 2019-04-16 à 16 20 02" src="https://user-images.githubusercontent.com/4760796/56217443-8de2f180-6063-11e9-83ea-e1bf53210752.png">

**After**
<img width="506" alt="Capture d’écran 2019-04-16 à 16 20 06" src="https://user-images.githubusercontent.com/4760796/56217451-8facb500-6063-11e9-90ed-dc53a88eb5e9.png">
