### PR TITLE
Remove 'property' and 'union' as keywords. Add missing keywords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,7 +142,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings 
+# TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj
@@ -241,3 +241,5 @@ paket-files/*
 .fake/
 issueList.md
 /**/node_modules/*
+
+.ionide/

--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -237,7 +237,7 @@
                 },
                 {
                     "name": "keyword.fsharp",
-                    "match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|union|enum|member|try|finally|and|when|or|use|use\\!|struct|while|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|void)(?!')\\b"
+                    "match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|enum|member|try|finally|and|when|or|use|use\\!|struct|while|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast)(?!')\\b"
                 },
                 {
                     "name": "keyword.fsharp",
@@ -600,7 +600,7 @@
                 },
                 {
                     "name": "constant.others.fsharp",
-                    "match": "\\b(true|false|null|unit)\\b"
+                    "match": "\\b(true|false|null|unit|void)\\b"
                 }
             ]
         },
@@ -1036,7 +1036,7 @@
             "patterns": [
                 {
                     "name": "keyword.fsharp",
-                    "match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|union|enum|member|try|finally|and|when|or|use|use\\!|struct|while|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|void)(?!')\\b"
+                    "match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|enum|member|try|finally|and|when|or|use|use\\!|struct|while|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast)(?!')\\b"
                 },
                 {
                     "name": "keyword.symbol.fsharp",
@@ -1048,7 +1048,7 @@
             "patterns": [
                 {
                     "name": "entity.name.section.fsharp",
-                    "begin": "\\b(namespace|module)\\s*(public|internal|private)?\\s+([[:alpha:]][[:alpha:]0-9'_. ]*)",
+                    "begin": "\\b(namespace|module)\\s*(public|internal|private|rec)?\\s+([[:alpha:]][[:alpha:]0-9'_. ]*)",
                     "end": "(\\s?=|\\s|$)",
                     "beginCaptures": {
                         "1": {

--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -237,7 +237,7 @@
                 },
                 {
                     "name": "keyword.fsharp",
-                    "match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|property|union|enum|member|try|finally|and|when|use|use\\!|struct|while|mutable)(?!')\\b"
+                    "match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|union|enum|member|try|finally|and|when|or|use|use\\!|struct|while|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|void)(?!')\\b"
                 },
                 {
                     "name": "keyword.fsharp",
@@ -1036,7 +1036,7 @@
             "patterns": [
                 {
                     "name": "keyword.fsharp",
-                    "match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|property|union|enum|member|try|finally|and|when|or|use|use\\!|struct|while|mutable)(?!')\\b"
+                    "match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|union|enum|member|try|finally|and|when|or|use|use\\!|struct|while|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|void)(?!')\\b"
                 },
                 {
                     "name": "keyword.symbol.fsharp",

--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -237,7 +237,7 @@
                 },
                 {
                     "name": "keyword.fsharp",
-                    "match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|enum|member|try|finally|and|when|or|use|use\\!|struct|while|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast)(?!')\\b"
+                    "match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|enum|member|try|finally|and|when|or|use|use\\!|struct|while|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|not)(?!')\\b"
                 },
                 {
                     "name": "keyword.fsharp",
@@ -977,6 +977,26 @@
                             "include": "#common_binding_definition"
                         }
                     ]
+                },
+                {
+                    "name": "binding.fsharp",
+                    "begin": "\\b(new)",
+                    "end": "(=)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.fsharp"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.fsharp"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#common_binding_definition"
+                        }
+                    ]
                 }
             ]
         },
@@ -1036,7 +1056,7 @@
             "patterns": [
                 {
                     "name": "keyword.fsharp",
-                    "match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|enum|member|try|finally|and|when|or|use|use\\!|struct|while|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast)(?!')\\b"
+                    "match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|enum|member|try|finally|and|when|or|use|use\\!|struct|while|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|not)(?!')\\b"
                 },
                 {
                     "name": "keyword.symbol.fsharp",
@@ -1048,7 +1068,7 @@
             "patterns": [
                 {
                     "name": "entity.name.section.fsharp",
-                    "begin": "\\b(namespace|module)\\s*(public|internal|private|rec)?\\s+([[:alpha:]][[:alpha:]0-9'_. ]*)",
+                    "begin": "\\b(namespace global)|(namespace|module)\\s*(public|internal|private|rec)?\\s+([[:alpha:]][[:alpha:]0-9'_. ]*)",
                     "end": "(\\s?=|\\s|$)",
                     "beginCaptures": {
                         "1": {
@@ -1058,6 +1078,9 @@
                             "name": "keyword.fsharp"
                         },
                         "3": {
+                            "name": "keyword.fsharp"
+                        },
+                        "4": {
                             "name": "entity.name.section.fsharp"
                         }
                     },

--- a/sample-code/SampleKeywords.fs
+++ b/sample-code/SampleKeywords.fs
@@ -1,0 +1,84 @@
+/// This file contains all the F# keywords
+
+namespace global
+
+open System
+open System.Collections
+
+type IType =
+    abstract member Getter : unit -> int
+
+type SType =
+    struct
+        val x: int
+        new (x: int) = { x = x }
+    end
+
+type AType () as self =
+    class
+        override this.ToString () = "AType"
+        abstract member Rotate: float -> unit
+        default this.Rotate(delta : float) = ()
+    end
+
+and MyType<'T when 'T : null and 'T : not struct> =
+    inherit AType
+    interface IType with
+        member this.Getter () = 42
+    static member Getter () = 42
+
+    override self.ToString () =
+        base.ToString ()
+
+type Fn = delegate of int -> unit
+type Color = | Red = 0 | Green = 1 | Blue = 2
+
+exception ErrorException of string
+
+module rec Keywords =
+    extern void test ()
+
+    let anotherProperty = "not a keyword"
+    let property = "not a keyword"
+    let union = "not a keyword"
+
+    let public sampleKeywords (error: exn) =
+        begin
+            printfn "%A" Keywords.union
+            printfn "%A" Keywords.property
+            printfn "%A" Keywords.anotherProperty
+
+            let a = true or false
+            let b = lazy function | Some x -> x | None -> 0
+            let mutable value = [ yield! [ yield 42 ] ]
+            let b = enum<Color>(3)
+            let s = [| 42 |]
+            use ptr = fixed &s.[0]
+            try
+                new AType ()
+            finally
+                while true do
+                    ()
+        end
+
+    let rec private myFunc (arg : int) =
+        for x = 1 to 10 do
+            for y = 10 downto 1 do
+                for z in Seq.empty do
+                    ()
+                done
+
+        match arg with | 42 -> () | _ -> assert true
+
+    let inline internal myInternalFunc () =
+        async {
+            let b : IEnumerable = upcast Seq.empty
+            let c : int seq = downcast b
+
+            let x = if Seq.isEmpty c then 1 elif Seq.contains 2 c then 2 else 3
+            use! a = async {
+                let a: IDisposable = null
+                return a }
+            return! async { return () }
+        }
+


### PR DESCRIPTION
Removes `property` and `union` as keywords. Adds `or` to one of the match strings (since it's in the other match string). Also adds the missing keywords  `assert`, `base`, `done` `downcast`, `downto`, `extern`,  `fixed`, `global`, `lazy`, `upcast`, `void` as listed in the [keyword reference] (https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/keyword-reference). Not sure why they are not already added but let's use this PR to find out.