### PR TITLE
Fix #135: Secure new capture with a word-break check

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -980,7 +980,7 @@
                 },
                 {
                     "name": "binding.fsharp",
-                    "begin": "\\b(new)",
+                    "begin": "\\b(new)\\b",
                     "end": "(=)",
                     "beginCaptures": {
                         "1": {


### PR DESCRIPTION
**Before**
<img width="308" alt="Capture d’écran 2019-07-05 à 10 10 48" src="https://user-images.githubusercontent.com/4760796/60708040-68041500-9f0d-11e9-9216-52d160f503b0.png">

**After**
<img width="338" alt="Capture d’écran 2019-07-05 à 10 10 52" src="https://user-images.githubusercontent.com/4760796/60708044-6a666f00-9f0d-11e9-8d91-edd169954091.png">

@Krzysztof-Cieslak Can you please realese a new version of Ionide with this fix because this can break the syntax on a whole file. At work, I have the case where 300-400 lines are not correct.
