### PR TITLE
Support `\xHH` escape in string literals

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -1239,11 +1239,11 @@
                         },
                         {
                             "name": "constant.character.string.escape.fsharp",
-                            "match": "\\\\([\\\\''ntbr]|u[a-fA-F0-9]{4}|u[a-fA-F0-9]{8})"
+                            "match": "\\\\([\\\\''ntbr]|x[a-fA-F0-9]{2}|u[a-fA-F0-9]{4}|u[a-fA-F0-9]{8})"
                         },
                         {
                             "name": "invalid.illeagal.character.string.fsharp",
-                            "match": "\\\\(?![\\\\''ntbr]|u[a-fA-F0-9]{4}|u[a-fA-F0-9]{8})."
+                            "match": "\\\\(?![\\\\''ntbr]|x[a-fA-F0-9]{2}|u[a-fA-F0-9]{4}|u[a-fA-F0-9]{8})."
                         },
                         {
                             "include": "#string_formatter"

--- a/sample-code/SimpleBindings.fs
+++ b/sample-code/SimpleBindings.fs
@@ -59,6 +59,7 @@ printf "%1e" 1.0
 printf "sss  %-1e" 2.
 printf "%-10s" "2"
 printf "%020.1f" 0.2f
+printfn "\x00 \x1a \xff \x1g" // 1g is invalid
 
 sprintf "75.9%% ss"
 sprintf """


### PR DESCRIPTION
This PR updates the grammar to support `\xHH` escape in string literals. (H is a hex digit)

Reference: [Strings - F# | Microsoft Docs](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/strings)

Example: In `"\x00 \x1a \xff \x1g"`, `\x00`, `\x1a`, `\xff` becomes the color same as `\n` in string literals. `\x` before `1g` doesn't change.