### PR TITLE
Make sure that module/namespace keywords are preceded by a word break

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -1074,7 +1074,7 @@
             "patterns": [
                 {
                     "name": "entity.name.section.fsharp",
-                    "begin": "\\b(namespace global)|(namespace|module)\\s*(public|internal|private|rec)?\\s+([[:alpha:]][[:alpha:]0-9'_. ]*)",
+                    "begin": "\\b(namespace global)|\\b(namespace|module)\\s*(public|internal|private|rec)?\\s+([[:alpha:]][[:alpha:]0-9'_. ]*)",
                     "end": "(\\s?=|\\s|$)",
                     "beginCaptures": {
                         "1": {

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -417,6 +417,11 @@ let a =
         return a
     }
 
+// Test case for: https://github.com/ionide/ionide-fsgrammar/issues/147
+let testVariableWithModuleKeyword test_module =
+    if test_module then // This is the line where the problem is
+        ()
+
 // Edge cases provided by @selketjah
 // In this code some of the `type` word where colored in purple
 type Example =


### PR DESCRIPTION
Fix #147

**Before**
![image](https://user-images.githubusercontent.com/4760796/73937760-13cb7400-48e6-11ea-9b24-df4bffec376d.png)

**After**
![image](https://user-images.githubusercontent.com/4760796/73937778-1b8b1880-48e6-11ea-91cd-2b035085c5cb.png)
