### PR TITLE
More accurate token names

### DIFF
--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -596,7 +596,7 @@
                     "match": "\\(\\)"
                 },
                 {
-                    "name": "constant.numeric.floating-point.fsharp",
+                    "name": "constant.numeric.float.fsharp",
                     "match": "\\b-?[0-9][0-9_]*((\\.([0-9][0-9_]*([eE][+-]??[0-9][0-9_]*)?)?)|([eE][+-]??[0-9][0-9_]*))"
                 },
                 {
@@ -604,7 +604,7 @@
                     "match": "\\b(-?((0(x|X)[0-9a-fA-F][0-9a-fA-F_]*)|(0(o|O)[0-7][0-7_]*)|(0(b|B)[01][01_]*)|([0-9][0-9_]*)))"
                 },
                 {
-                    "name": "constant.others.fsharp",
+                    "name": "constant.other.fsharp",
                     "match": "\\b(true|false|null|unit|void)\\b"
                 }
             ]

--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -922,7 +922,7 @@
                             "name": "support.function.attribute.fsharp"
                         },
                         "4": {
-                            "name": "keyword.fsharp"
+                            "name": "storage.modifier.fsharp"
                         },
                         "5": {
                             "name": "variable.fsharp"
@@ -974,7 +974,7 @@
                             "name": "support.function.attribute.fsharp"
                         },
                         "4": {
-                            "name": "keyword.fsharp"
+                            "name": "storage.modifier.fsharp"
                         },
                         "5": {
                             "name": "variable.fsharp"
@@ -1089,7 +1089,7 @@
                             "name": "keyword.fsharp"
                         },
                         "3": {
-                            "name": "keyword.fsharp"
+                            "name": "storage.modifier.fsharp"
                         },
                         "4": {
                             "name": "entity.name.section.fsharp"
@@ -1511,7 +1511,7 @@
                             "name": "keyword.fsharp"
                         },
                         "2": {
-                            "name": "keyword.fsharp"
+                            "name": "storage.modifier.fsharp"
                         }
                     },
                     "endCaptures": {
@@ -1623,7 +1623,7 @@
                                     "name": "keyword.symbol.fsharp"
                                 },
                                 "2": {
-                                    "name": "keyword.fsharp"
+                                    "name": "storage.modifier.fsharp"
                                 }
                             }
                         },

--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -1066,11 +1066,23 @@
         "keywords": {
             "patterns": [
                 {
-                    "name": "keyword.fsharp",
-                    "match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|enum|member|try|finally|and|when|or|use|use\\!|struct|while|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|not)(?!')\\b"
+                    "name": "storage.modifier",
+                    "match": "\\b(private|public|internal)\\b"
                 },
                 {
-                    "name": "keyword.symbol.fsharp",
+                    "name": "keyword.fsharp",
+                    "match": "\\b(private|to|public|internal|function|class|exception|delegate|of|as|begin|end|inherit|let!|interface|abstract|enum|member|and|when|or|use|use\\!|struct|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|not)(?!')\\b"
+                },
+                {
+                    "name": "keyword.control",
+                    "match": "\\b(match|yield|yield!|with|if|then|else|elif|for|in|return!|return|try|finally|while|do)(?!')\\b"
+                },
+                {
+                    "name": "keyword.operator.new",
+                    "match": "\\b(new)\\b"
+                },
+                {
+                    "name": "keyword.operator.builtin.fsharp",
                     "match": "(&&&|\\|\\|\\||\\^\\^\\^|~~~|<<<|>>>|\\|>|\\->|\\<\\-|:>|:\\?>|:|\\[|\\]|\\;|<>|=|@|\\|\\||&&|{|}|\\||_|\\.\\.|\\,|\\+|\\-|\\*|\\/|\\^|\\!|\\>|\\>\\=|\\>\\>|\\<|\\<\\=|\\(|\\)|\\<\\<)"
                 }
             ]

--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -1774,8 +1774,8 @@
         "compiler_directives": {
             "patterns": [
                 {
-                    "name": "compiler_directive.fsharp",
-                    "match": "\\s?(#if|#elif|#else|#elseif|#endif|#light|#nowarn)",
+                    "name": "keyword.control.directive.fsharp",
+                    "match": "\\s?(#if|#elif|#elseif|#else|#endif|#light|#nowarn)",
                     "captures": {}
                 }
             ]

--- a/grammar/fsharp.json
+++ b/grammar/fsharp.json
@@ -475,7 +475,7 @@
                     },
                     "endCaptures": {
                         "1": {
-                            "name": "keyword.fsharp"
+                            "name": "keyword.operator.arrow.fsharp"
                         }
                     },
                     "patterns": [
@@ -487,12 +487,12 @@
                             "end": "\\s*(?=(->))",
                             "beginCaptures": {
                                 "1": {
-                                    "name": "keyword.symbol.fsharp"
+                                    "name": "keyword.operator.arrow.fsharp"
                                 }
                             },
                             "endCaptures": {
                                 "1": {
-                                    "name": "keyword.symbol.fsharp"
+                                    "name": "keyword.operator.arrow.fsharp"
                                 }
                             },
                             "patterns": [


### PR DESCRIPTION
Renamed numeric tokens to match TextMate name rules
Added access-modifiers as different tokens (storage.modifier instead of keyword)