### PR TITLE
Fix #155: Prevent // comment rules inside a block comment

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -560,6 +560,11 @@
                     },
                     "patterns": [
                         {
+                            "comments": "Capture // when inside of (* *) like that the rule which capture comments starting by // is not trigger. See https://github.com/ionide/ionide-fsgrammar/issues/155",
+                            "name": "fast-capture.comment.line.double-slash.fsharp",
+                            "match":  "//"
+                        },
+                        {
                             "include": "#comments"
                         }
                     ]

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -48,6 +48,8 @@ file as markdown
     *)
     let d = ""
 
+    let e = (* comment// *) "not a comment"
+
 /// **Description**
 ///
 /// **Parameters**


### PR DESCRIPTION
**Before**

![image](https://user-images.githubusercontent.com/4760796/99444993-3e3e6900-291d-11eb-8849-21b8c9537c01.png)


**After**

![image](https://user-images.githubusercontent.com/4760796/99445006-426a8680-291d-11eb-9049-d193a2d13896.png)
