### PR TITLE
Prevent single star operator (*) to be captured as a comment

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -571,7 +571,7 @@
                 },
                 {
                     "name": "comment.block.markdown.fsharp.end",
-                    "match": "((\\*)+\\))",
+                    "match": "((?<!\\()(\\*)+\\))",
                     "captures": {
                         "1": {
                             "name": "comment.block.fsharp"

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -35,6 +35,8 @@ module Test =
     *)
     let b = ""
 
+    let double = (*) 2 // *) was being captured as a comment
+
     (**
 This block is colorized because markdown can set up his context.
 


### PR DESCRIPTION
**Before**
![image](https://user-images.githubusercontent.com/4760796/143941351-d9243bc1-f7c7-4ac6-a05c-358ede497485.png)


**After**
![image](https://user-images.githubusercontent.com/4760796/143941343-2425069e-930f-406f-b4f9-9d3d9bc01ee2.png)

This doesn't cover case where user use the `*` several times example : `(*****)` but this is better than nothing and should be enough for now.