### PR TITLE
Add special rule for Literate command via comments

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -525,6 +525,15 @@
         "comments": {
             "patterns": [
                 {
+                    "name": "comment.literate.command.fsharp",
+                    "match": "(\\(\\*{3}.*\\*{3}\\))",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "comment.block.fsharp"
+                        }
+                    }
+                },
+                {
                     "name": "comment.block.markdown.fsharp",
                     "begin": "^\\s*(\\(\\*\\*(?!\\)))((?!\\*\\)).)*$",
                     "while": "^(?!\\s*(\\*)+\\)$)",

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -1,7 +1,14 @@
 ﻿(**
-# First-level heading
-Some more documentation using `Markdown`.
-*)
+---
+layout: standard
+title: Manual
+---
+**)
+
+// The next comment was making the rest of the file render
+// as a comment until another comment was breaking the flow
+(*** hide ***)
+
 module SampleCode.SimpleTypes
 
 (**


### PR DESCRIPTION
I don't really like adding specific rule, but I spent 1 hour without finding a better way to handle it. So for now, it will have to do ^^

**Before**

![image](https://user-images.githubusercontent.com/4760796/144567783-fce97faf-a8aa-4766-8c3a-10345de11d61.png)

**After**

![image](https://user-images.githubusercontent.com/4760796/144567821-cddb0e54-324c-48bb-98ca-8ed3310f7700.png)
