### PR TITLE
Allow white space after ending markdown comment.

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -536,7 +536,7 @@
                 {
                     "name": "comment.block.markdown.fsharp",
                     "begin": "^\\s*(\\(\\*\\*(?!\\)))((?!\\*\\)).)*$",
-                    "while": "^(?!\\s*(\\*)+\\)$)",
+                    "while": "^(?!\\s*(\\*)+\\)\\s*$)",
                     "beginCaptures": {
                         "1": {
                             "name": "comment.block.fsharp"


### PR DESCRIPTION
Fixes #166 by allowing whitespace between "*)" and the end of the line in a closing markdown comment.

![syntax](https://user-images.githubusercontent.com/5226115/156922659-75d0fe11-b4a3-490c-a228-c8b4ba95768a.gif)

