### PR TITLE
Fix displaying unbalanced comments

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -556,7 +556,7 @@
                 {
                     "name": "comment.block.fsharp",
                     "begin": "(\\(\\*(?!\\)))",
-                    "end": "(\\*\\))",
+                    "end": "(\\**\\))",
                     "beginCaptures": {
                         "1": {
                             "name": "comment.block.fsharp"

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -61,6 +61,8 @@ file as markdown
     *)
     let d = ""
 
+
+    (* Unbalanced comment, which turn everything after itself into comment **)
     let e = (* comment// *) "not a comment"
 
 /// **Description**


### PR DESCRIPTION
When comment ends with `**)` or with more stars
trigger everything into comment after myself