### PR TITLE
Fix #172: Add missing bindings support

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -959,6 +959,29 @@
                 },
                 {
                     "name": "binding.fsharp",
+                    "begin": "\\b(use|use\\!|and|and!)\\s*(\\[[^-=]*\\]|[_[:alpha:]]([_[:alpha:]0-9\\._]+)*|``[_[:alpha:]]([_[:alpha:]0-9\\._`\\s]+|(?<=,)\\s)*)?",
+                    "end": "\\s*(=)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.fsharp"
+                        },
+                        "2": {
+                            "name": "variable.fsharp"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.fsharp"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#common_binding_definition"
+                        }
+                    ]
+                },
+                {
+                    "name": "binding.fsharp",
                     "begin": "(?<=with|and)\\s*\\b((get|set)\\s*(?=\\())(\\[[^-=]*\\]|[_[:alpha:]]([_[:alpha:]0-9\\._]+)*|``[_[:alpha:]]([_[:alpha:]0-9\\._`\\s]+|(?<=,)\\s)*)?",
                     "end": "\\s*(=|\\n+=|(?<=\\=))",
                     "beginCaptures": {

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -710,3 +710,22 @@ let incorrect =
         }
         let loadedModel = { loadedModel with FormState = Form.setWaiting false loadedModel.FormState }
         ())
+
+// This code is used to check that we capture correctly all the variable in the binding
+
+let x = 1
+
+let rec y = 2
+and z = 3
+
+use d = new Disposable()
+
+let f =
+    foo {
+        let! a = bar
+        and! b = qux
+
+        use! c = fooBar
+
+        ()
+    }


### PR DESCRIPTION
- `use`
- `use!`
- `and`
- `and!`

See how the underline word are now colored.

**Before**
![image](https://user-images.githubusercontent.com/4760796/169538411-4c23ed11-db1c-4da9-a115-421c62c92581.png)

**After**
![image](https://user-images.githubusercontent.com/4760796/169538330-92f73c60-257f-4c73-a395-7bcf43a2c893.png)

