### PR TITLE
Fix: When no other matching rule: Variables starting with `and` or `use` break rule detection

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -959,7 +959,7 @@
                 },
                 {
                     "name": "binding.fsharp",
-                    "begin": "\\b(use|use\\!|and|and!)\\s*(\\[[^-=]*\\]|[_[:alpha:]]([_[:alpha:]0-9\\._]+)*|``[_[:alpha:]]([_[:alpha:]0-9\\._`\\s]+|(?<=,)\\s)*)?",
+                    "begin": "\\b(use|use!|and|and!)\\s+(\\[[^-=]*\\]|[_[:alpha:]]([_[:alpha:]0-9\\._]+)*|``[_[:alpha:]]([_[:alpha:]0-9\\._`\\s]+|(?<=,)\\s)*)?",
                     "end": "\\s*(=)",
                     "beginCaptures": {
                         "1": {

--- a/sample-code/SimpleBindings.fs
+++ b/sample-code/SimpleBindings.fs
@@ -112,3 +112,15 @@ module private test3 =
 
 module test4 =
     let x = 1
+
+let uses = None
+match uses with
+| Some uses -> ()
+| Some ands -> ()
+| uses -> ()
+| ands -> ()
+// ENHANCEMENT: Keywords should not change following tokens and highlighting
+//   -> string should still be recognized and highlighted as string
+// | and -> ()
+// | use -> ()
+"some string"


### PR DESCRIPTION
![MatchCaseUses](https://user-images.githubusercontent.com/15612932/181514443-84f838d4-aff6-430a-a8de-960a64497ecf.png)  
-> `"some string"` isn't highlighted as string

Example in practice:  
fsharp/FsAutoComplete -> [`FsAutoComplete.Lsp.fs`](https://github.com/fsharp/FsAutoComplete/blob/6ab77052f2c86e270c199d5389a7046b85d51ec1/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L1366):  Binding in match pattern to variable `uses` -> Syntax highlighting afterwards is broken.



**Reasons**:  
* Keywords `use` and `and` get detected as keyword. But regex doesn't require space afterwards -> detects keyword as long as word starts with `use` or `and` (-> `uses` -> detected as keyword)
* Unlike in let binding, there's no other (more important) token at location of `uses` -> detected as keyword, not as variable
  * for example: `let uses = ...` -> `uses` gets detected as `variable` and not as keyword
* `use` (and `and`) keyword rule matches to next `=` (and required some variable name before). That's ok in use binding. But because keyword gets detected in other places like match binding -> breaks following token detection.

**Fix**:  
Require at least one space after `use` or `and`  
![MatchCaseUsesFixed](https://user-images.githubusercontent.com/15612932/181514487-751d907c-035e-49c9-b1b6-74caaf57d7b8.png)


Note: Doesn't fix names exactly `use` or `and` (last point in list) (would require way more work)  
![MatchCaseUseNotFixed](https://user-images.githubusercontent.com/15612932/181514469-41281534-0129-4001-8d39-97157dd0df8b.png)

I think that's acceptable: Is invalid F# and not real code to keep around
