### PR TITLE
Fix incorrect tokenization of opening brackets for computation expressions

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -571,7 +571,7 @@
                         {
                             "comments": "Capture // when inside of (* *) like that the rule which capture comments starting by // is not trigger. See https://github.com/ionide/ionide-fsgrammar/issues/155",
                             "name": "fast-capture.comment.line.double-slash.fsharp",
-                            "match":  "//"
+                            "match": "//"
                         },
                         {
                             "include": "#comments"

--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -1791,7 +1791,7 @@
             "patterns": [
                 {
                     "name": "cexpr.fsharp",
-                    "match": "\\b(async|seq|promise|task|maybe|asyncMaybe|controller|scope|application|pipeline)\\s*\\{",
+                    "match": "\\b(async|seq|promise|task|maybe|asyncMaybe|controller|scope|application|pipeline)(?=\\s*\\{)",
                     "captures": {
                         "0": {
                             "name": "keyword.fsharp"

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -133,6 +133,10 @@ let d =
 // Whitespace between builder and opening brace is optional
 let e = async{ return 0 }
 
+// Make the sure opening and closing bracket colors match when the color
+// used for keywords is different than the color used for brackets
+let f = seq { yield! seq { yield 1 } }
+
 type FancyClass(thing:int, var2 : string -> string, ``ddzdz``: string list, extra) as xxx =
 
     let pf() = xxx.Test()


### PR DESCRIPTION
The builder name of a computation expression is tokenized as `keyword.fsharp`. Opening and closing brackets are normally tokenized as `keyword.symbol.fsharp`. But for computation expressions, the opening bracket symbol is incorrectly being tokenized as if it were part of the builder name. The closing bracket is still tokenized correctly.

You probably won't notice this problem if you use the default color scheme in VS Code because keywords and symbols are the same color by default. But if you configure your color scheme to use a different color for symbols, you can have cases where opening brackets are a different color than their corresponding closing brackets. In the "before" screenshot below, notice that some of the opening brackets are blue (incorrect) while the closing brackets are always white (correct). Both opening and closing brackets should be white, as shown in the "after" screenshot.

My fix keeps the regular expression match as-is, but excludes the whitespace and opening bracket from the capture.

Before:
![shot-1](https://user-images.githubusercontent.com/1977895/235850511-f3ab516b-0ffb-4e7e-837f-0f280c535be8.png)

After:
![shot-2](https://user-images.githubusercontent.com/1977895/235850551-3cdaf4c3-9671-4af5-97dd-7ef352c468c4.png)
