### PR TITLE
Fix incorrect tokenization in lambda expressions

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -487,7 +487,7 @@
                             "end": "\\s*(?=(->))",
                             "beginCaptures": {
                                 "1": {
-                                    "name": "keyword.symbol.arrow.fsharp"
+                                    "name": "keyword.symbol.fsharp"
                                 }
                             },
                             "endCaptures": {

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -133,7 +133,7 @@ let d =
 // Whitespace between builder and opening brace is optional
 let e = async{ return 0 }
 
-// Make the sure opening and closing bracket colors match when the color
+// Make sure the opening and closing bracket colors match when the color
 // used for keywords is different than the color used for brackets
 let f = seq { yield! seq { yield 1 } }
 
@@ -504,6 +504,19 @@ type AR_Class () =
 
 // Check anonymous function type signature
 let tx = fun (t : ``type with spaces``) (``var with spaces`` : Result<obj list, int>) -> ()
+
+// Make sure the opening and closing parenthesis colors match when using
+// a distinct color for the arrow symbol
+let lambda0 = fun x -> x
+let lambda1 = fun (x) -> x
+let lambda2 = fun (x) (y) -> x
+let lambda3 = fun (x, y) -> x
+let lambda4 = fun ((x, y), z) -> x
+let lambda5 = (fun x -> x)
+let lambda6 = (fun (x) -> x)
+let lambda7 = (fun (x) (y) -> x)
+let lambda8 = (fun (x, y) -> x)
+let lambda9 = (fun ((x, y), z) -> x)
 
 let private mixedArray msg (decoders: string []) (path: string) (values: obj[]): Result<obj list, int> =
     Ok []


### PR DESCRIPTION
The arrow symbol in lambda expressions is tokenized as `keyword.symbol.arrow.fsharp`. This lets you override the normal symbol color if you want a distinct color for the arrow symbol. The problem is that if the lambda expression has a tuple parameter enclosed in parentheses, the opening parenthesis is incorrectly picking up the arrow color as well. See screenshots below.

My fix does not change any of the regular expressions. It just changes the token name associated with the opening parenthesis.

Before:
![shot-1](https://user-images.githubusercontent.com/1977895/236575462-cc60f562-00cd-454d-8251-c54b58e52cb0.png)

After:
![shot-2](https://user-images.githubusercontent.com/1977895/236575479-d95ff12f-ece6-43fd-8962-f319a047c575.png)

You won't notice this issue if you're using the default color scheme in VS Code. You can use the following color configuration in your `settings.json` file if you want to reproduce it visually:

    "editor.tokenColorCustomizations": {

        // ...

        "textMateRules": [
            {
                "scope": [
                    "source.fsharp keyword"
                ],
                "settings": {
                    "foreground": "#569cd6"
                }
            },
            {
                "scope": [
                    "source.fsharp keyword.symbol"
                ],
                "settings": {
                    "foreground": "#d4d4d4"
                }
            },
            {
                "scope": [
                    "source.fsharp keyword.symbol.arrow"
                ],
                "settings": {
                    "foreground": "#ff8080"
                }
            }
        ]
    }
