### PR TITLE
Fix inconsistent tokenization of equal signs

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -928,7 +928,7 @@
                 {
                     "name": "binding.fsharp",
                     "begin": "\\b(let mutable|static let mutable|static let|let inline|let|and|member val|static member inline|static member|default|member|override|let!)(\\s+rec|mutable)?(\\s+\\[\\<.*\\>\\])?\\s*(private|internal|public)?\\s+(\\[[^-=]*\\]|[_[:alpha:]]([_[:alpha:]0-9\\._]+)*|``[_[:alpha:]]([_[:alpha:]0-9\\._`\\s]+|(?<=,)\\s)*)?",
-                    "end": "\\s*(with\\b|=|\\n+=|(?<=\\=))",
+                    "end": "\\s*((with\\b)|(=|\\n+=|(?<=\\=)))",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.fsharp"
@@ -947,8 +947,11 @@
                         }
                     },
                     "endCaptures": {
-                        "1": {
+                        "2": {
                             "name": "keyword.fsharp"
+                        },
+                        "3": {
+                            "name": "keyword.symbol.fsharp"
                         }
                     },
                     "patterns": [
@@ -968,7 +971,7 @@
                     },
                     "endCaptures": {
                         "1": {
-                            "name": "keyword.fsharp"
+                            "name": "keyword.symbol.fsharp"
                         }
                     },
                     "patterns": [
@@ -988,7 +991,7 @@
                     },
                     "endCaptures": {
                         "1": {
-                            "name": "keyword.fsharp"
+                            "name": "keyword.symbol.fsharp"
                         }
                     },
                     "patterns": [
@@ -1207,7 +1210,7 @@
                             "name": "entity.name.type.namespace.fsharp"
                         },
                         "3": {
-                            "name": "punctuation.separator.namespace-definition.fsharp"
+                            "name": "keyword.symbol.fsharp"
                         },
                         "4": {
                             "name": "entity.name.section.fsharp"

--- a/sample-code/SimpleBindings.fs
+++ b/sample-code/SimpleBindings.fs
@@ -124,3 +124,48 @@ match uses with
 // | and -> ()
 // | use -> ()
 "some string"
+
+// Make sure the equal signs are all the same color, particularly when
+// using different colors for keywords than for symbols
+module EqualSignTest =
+
+    module Opt = Option
+
+    type Foo() =
+
+        let mutable waldo = 0
+
+        member this.A = waldo
+        member this.B with set (value) = waldo <- value
+        member this.C with get () = waldo and set (value) = waldo <- value
+        member this.D with get () = waldo
+
+    and Bar() =
+
+        interface System.IDisposable with member this.Dispose() = ()
+
+        member val A = 11
+        member val B = 22 with get, set
+
+    let quux =
+        let foo = new Foo()
+        use bar = new Bar()
+        task {
+            let! fred = task { return new Foo() }
+            use! barb = task { return new Bar() }
+            return (fred, barb)
+        }
+
+    type Boo = { A : int; B : int }
+    let boom = { A = 123; B = 456 }
+    let buzz = { boom with B = 789 }
+
+    type Goo =
+        val a : int
+        val b : int
+        new(a0, b0) = { a = a0; b = b0; }
+
+    let rec bee x =
+        bop (x - 1)
+    and bop y =
+        if (y = 0) then 0 else bee y


### PR DESCRIPTION
The equal signs are being not tokenized consistently. See screenshots below. It looks like there are three different tokens being used for equal signs:

* `keyword.symbol.fsharp`
* `keyword.fsharp`
* `punctuation.separator.namespace-definition.fsharp`

I think `keyword.symbol.fsharp` is the correct one. In the "before" screenshot below, you can observe that sometimes the equal signs are yellow (correct), sometimes they are blue (incorrect), and sometimes they are white (incorrect). In the "after" screenshot, all the equal signs are yellow.

My fix ensures that all equal signs use a consistent token name. There is only one spot where I had to modify a regular expression. I did not change the pattern match. I only added subgroups so that the `with` keyword can be captured separately from the `=` symbol.

Before:
![shot-1](https://user-images.githubusercontent.com/1977895/236719594-3859ee61-8bbc-4b59-a62b-7c693579bff9.png)

After:
![shot-2](https://user-images.githubusercontent.com/1977895/236719615-b2a80d56-f7f9-4f70-8974-d9803616085a.png)

Like my previous pull requests (#184, #185), this issue may not be visible if you're using the default color scheme in VS Code. You can use the following color customization settings to reproduce visually:

    "editor.tokenColorCustomizations": {
        "textMateRules": [
            {
                "scope": [
                    "source.fsharp keyword",
                    "source.fsharp keyword.control",
                    "source.fsharp keyword.symbol.new"
                ],
                "settings": {
                    "foreground": "#569cd6"
                }
            },
            {
                "scope": [
                    "source.fsharp constant.language.unit",
                    "source.fsharp keyword.symbol"
                ],
                "settings": {
                    "foreground": "#ffff80"
                }
            }
        ]
    }

After applying the fix, you can use the inspection tool in VS Code to verify that all the equal signs have the same textmate scope. See below:

![shot-3](https://user-images.githubusercontent.com/1977895/236720341-e90d917a-767b-4f7f-9540-f6f61110b6e0.png)

I was also careful to make sure the tokenization of the `with` keyword would not be affected by this change. See below:

![shot-4](https://user-images.githubusercontent.com/1977895/236720354-8309ae13-1ceb-4fb8-a3f4-6e3e7f0bad31.png)
