### PR TITLE
Fix incorrect tokens for constructor parentheses

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -1036,12 +1036,12 @@
                             "name": "keyword.fsharp"
                         },
                         "2": {
-                            "name": "keyword.fsharp"
+                            "name": "keyword.symbol.fsharp"
                         }
                     },
                     "endCaptures": {
                         "1": {
-                            "name": "keyword.fsharp"
+                            "name": "keyword.symbol.fsharp"
                         }
                     },
                     "patterns": [

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -746,3 +746,17 @@ let f =
 
         ()
     }
+
+// The opening and closing parentheses following the `new` keyword in the
+// constructors should always use the symbol color, regardless of whether
+// or not there is a space after the `new` keyword
+
+type FooWithNoSpaceAfterNew =
+    val a : int
+    new() = { a = 0 }
+    new(b) = { a = b }
+
+type FooWithSpaceAfterNew =
+    val a : int
+    new () = { a = 0 }
+    new (b) = { a = b }


### PR DESCRIPTION
The parentheses in type constructors are not picking up the correct symbol color if there is whitespace between the `new` keyword and the `(` symbol. See screenshots below.

Before:
![shot-1](https://github.com/ionide/ionide-fsgrammar/assets/1977895/c931af7a-722a-4238-91ad-11307ec6a689)

After:
![shot-2](https://github.com/ionide/ionide-fsgrammar/assets/1977895/73bb154a-f984-4e23-b47d-902b6040328d)

This is another one of those things you won't notice if you're using the default color scheme in VS Code. You can use the following color configurations to reproduce:


    "editor.tokenColorCustomizations": {
        "textMateRules": [
            {
                "scope": [
                    "source.fsharp keyword",
                    "source.fsharp keyword.symbol.new"
                ],
                "settings": {
                    "foreground": "#569cd6"
                }
            },
            {
                "scope": [
                    "source.fsharp constant.language.unit",
                    "source.fsharp keyword.symbol"
                ],
                "settings": {
                    "foreground": "#ffff80"
                }
            }
        ]
    }

This fix only changes the token names associated with the opening and closing parentheses. There are no changes to any of the regular expressions.

**Side note:** While this PR fixes the immediate issue, the fact that the presence or absence of whitespace between `new` and `(` causes this construct to be matched at completely different places in the grammar definition seems a bit odd to me. I also noticed that the `()` on line 756 is being captured as a single token, whereas the `(` and `)` on line 761 are captured as two separate tokens. I haven't gotten in deep enough yet to get my head around it, but I wanted to make a note of my observations.
