### PR TITLE
Fix incorrect tokens for angle brackets and colons

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -240,7 +240,7 @@
                     "match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|enum|member|try|finally|and|when|or|use|use\\!|struct|while|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|not)(?!')\\b"
                 },
                 {
-                    "name": "keyword.fsharp",
+                    "name": "keyword.symbol.fsharp",
                     "match": ":"
                 },
                 {
@@ -1607,12 +1607,12 @@
                             "end": "((?<!:)>)",
                             "beginCaptures": {
                                 "1": {
-                                    "name": "keyword.fsharp"
+                                    "name": "keyword.symbol.fsharp"
                                 }
                             },
                             "endCaptures": {
                                 "1": {
-                                    "name": "keyword.fsharp"
+                                    "name": "keyword.symbol.fsharp"
                                 }
                             },
                             "patterns": [

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -760,3 +760,22 @@ type FooWithSpaceAfterNew =
     val a : int
     new () = { a = 0 }
     new (b) = { a = b }
+
+// The opening and closing angle brackets `<` and `>` for generics should
+// always use the symbol color and not the keyword color. Also, the colon
+// symbol `:` and casting operator `:>` should use the symbol color.
+
+type GenericType1<'a> =
+    class end
+
+type GenericType2<'a when 'a :> obj> =
+    class end
+
+type GenericType3<'a when 'a : enum<int>> =
+    class end
+
+let genericFunc1<'a> (x : 'a) = x
+
+let genericFunc2<'a when 'a :> obj> (x : 'a) = x
+
+let genericFunc3<'a when 'a : enum<int>> (x : 'a) = x


### PR DESCRIPTION
Angle brackets and colon symbols are not being treated consistently. In the "before" screenshot below, notice that the `<`, `>`, and `:` symbols are not colored consistently. Sometimes they are yellow (correct). Sometimes they are blue (incorrect). In the "after" screenshot, they are always yellow. This fix just changes the token names. There are no changes to the regular expressions.

Before:
![shot-1](https://github.com/ionide/ionide-fsgrammar/assets/1977895/7f6890c2-8d41-4f43-85a1-f8ca4dd31e65)


After:
![shot-2](https://github.com/ionide/ionide-fsgrammar/assets/1977895/72c6579a-e939-4ab0-a91b-ace7b7bdf419)

Like some of my previous pull requests, this is something you might not notice if you're using the default color scheme in VS Code. To reproduce, you can set your color customization settings to something like this:

    "editor.tokenColorCustomizations": {
        "textMateRules": [
            {
                "scope": [
                    "source.fsharp keyword"
                ],
                "settings": {
                    "foreground": "#569cd6"
                }
            },
            {
                "scope": [
                    "source.fsharp keyword.symbol"
                ],
                "settings": {
                    "foreground": "#ffff80"
                }
            }
        ]
    }

**Side note:** If you look carefully at line 774 in the "before" screenshot, it looks like the outer scope closes before the inner scope does. Suspicious. There might be a subtle bug lurking somewhere related to nested scopes. Also, I noticed that the `:>` operator on line 771 is captured as a single token, whereas it gets captured as two separate tokens on line 779.
