### PR TITLE
Add missing file reference to project file

### DIFF
--- a/sample-code/SampleCode.fsproj
+++ b/sample-code/SampleCode.fsproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="SampleKeywords.fs" />
     <Compile Include="SimpleBindings.fsi" />
     <Compile Include="SimpleBindings.fs" />
     <Compile Include="SimpleTypes.fsi" />


### PR DESCRIPTION
One of the sample code files was not referenced in the project file. The unreferenced file was not showing up in the F# solution explorer pane in the sidebar. No grammar changes.