### PR TITLE
Fix inconsistent treatment of the new keyword

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -1112,15 +1112,11 @@
                 },
                 {
                     "name": "keyword.fsharp",
-                    "match": "\\b(private|to|public|internal|function|class|exception|delegate|of|as|begin|end|inherit|let!|interface|abstract|enum|member|and|when|or|use|use\\!|struct|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|not)(?!')\\b"
+                    "match": "\\b(private|to|public|internal|function|class|exception|delegate|of|new|as|begin|end|inherit|let!|interface|abstract|enum|member|and|when|or|use|use\\!|struct|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|not)(?!')\\b"
                 },
                 {
                     "name": "keyword.control",
                     "match": "\\b(match|yield|yield!|with|if|then|else|elif|for|in|return!|return|try|finally|while|do)(?!')\\b"
-                },
-                {
-                    "name": "keyword.symbol.new",
-                    "match": "\\b(new)\\b"
                 },
                 {
                     "name": "keyword.symbol.fsharp",

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -749,7 +749,8 @@ let f =
 
 // The opening and closing parentheses following the `new` keyword in the
 // constructors should always use the symbol color, regardless of whether
-// or not there is a space after the `new` keyword
+// or not there is a space after the `new` keyword. And the `new` keyword
+// should always be the keyword color and not the symbol color.
 
 type FooWithNoSpaceAfterNew =
     val a : int


### PR DESCRIPTION
The `new` keyword is not being treated consistently. See screenshots below. There are two different token names being assigned for the `new` keyword, depending on the context in which it gets used:

* `keyword.fsharp`
* `keyword.symbol.new`

I think the use of `keyword.fsharp` is the correct one since that's how all the other keywords are treated. It doesn't make sense for the `new` keyword to be treated as a special type of operator symbol. And it can be confusing for new users trying to configure their color settings.

Before:
![shot-1](https://github.com/ionide/ionide-fsgrammar/assets/1977895/a2e1710f-3344-458e-a7bf-419afe042ec1)

After:
![shot-2](https://github.com/ionide/ionide-fsgrammar/assets/1977895/b293dc51-5939-4e38-af43-2376ab773b8c)

Here are the relevant VS Code color configurations:

    "editor.tokenColorCustomizations": {
        "textMateRules": [
            {
                "scope": [
                    "source.fsharp keyword"
                ],
                "settings": {
                    "foreground": "#569cd6"
                }
            },
            {
                "scope": [
                    "source.fsharp keyword.symbol"
                ],
                "settings": {
                    "foreground": "#ffff80"
                }
            }
        ]
    }

It looks like this issue originated in 959fa59. I think the contributor was trying to introduce some naming conventions that aligned closer to the [TextMate naming convention](https://macromates.com/manual/en/language_grammars#naming_conventions) recommendations. And then later, those names were modified in 19cd230 and af2a9a8, presumably to better align with the preexisting conventions used within this repo. So this issue seems to be the result of a mixup between two different naming conventions. I think the approach I'm taking here aligns best with the established conventions predominant within this repo.