### PR TITLE
Fix incorrect tokens for colons in abstract member definition

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -642,7 +642,7 @@
                     "name": "support.function.attribute.fsharp"
                 },
                 "5": {
-                    "name": "keyword.fsharp"
+                    "name": "keyword.symbol.fsharp"
                 }
             },
             "endCaptures": {

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -766,7 +766,7 @@ type FooWithSpaceAfterNew =
 // symbol `:` and casting operator `:>` should use the symbol color.
 
 type GenericType1<'a> =
-    abstract member Foo : 'a -> 'a
+    class end
 
 type GenericType2<'a when 'a :> obj> =
     class end
@@ -779,3 +779,6 @@ let genericFunc1<'a> (x : 'a) = x
 let genericFunc2<'a when 'a :> obj> (x : 'a) = x
 
 let genericFunc3<'a when 'a : enum<int>> (x : 'a) = x
+
+type AbstractType =
+    abstract member Foo : unit -> unit

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -766,7 +766,7 @@ type FooWithSpaceAfterNew =
 // symbol `:` and casting operator `:>` should use the symbol color.
 
 type GenericType1<'a> =
-    class end
+    abstract member Foo : 'a -> 'a
 
 type GenericType2<'a when 'a :> obj> =
     class end


### PR DESCRIPTION
This is similar to the change in #190. I found another case where the colon symbol `:` was getting the wrong token name. See before and after screenshots.

Before:
![shot-1](https://github.com/ionide/ionide-fsgrammar/assets/1977895/40061b67-acf0-485e-a48c-710f1bd302ff)

After:
![shot-2](https://github.com/ionide/ionide-fsgrammar/assets/1977895/5761fee6-8b87-4bac-9194-da85d8005105)
