### PR TITLE
Fix incorrect tokenization for access modifier

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -1673,9 +1673,6 @@
                             "match": "\\s*(private|internal|public)",
                             "captures": {
                                 "1": {
-                                    "name": "keyword.symbol.fsharp"
-                                },
-                                "2": {
                                     "name": "storage.modifier.fsharp"
                                 }
                             }


### PR DESCRIPTION
One of the access modifiers was incorrectly getting the symbol color.

Before:
![shot-1](https://github.com/ionide/ionide-fsgrammar/assets/1977895/4a32fce7-254f-432f-9bd0-1f43d0eeeccb)

After:
![shot-2](https://github.com/ionide/ionide-fsgrammar/assets/1977895/d9cbf45c-5b91-4121-8c62-ad3d3e4671c9)

Here are the relevant VS Code color configurations for this example:

    "editor.tokenColorCustomizations": {
        "textMateRules": [
            {
                "scope": [
                    "source.fsharp keyword",
                    "source.fsharp storage.modifier"
                ],
                "settings": {
                    "foreground": "#569cd6"
                }
            },
            {
                "scope": [
                    "source.fsharp keyword.symbol"
                ],
                "settings": {
                    "foreground": "#ffff80"
                }
            }
        ]
    }