### PR TITLE
Fix inconsistent arrow color

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -812,7 +812,7 @@
                     "match": "(->)\\s*(\\()?\\s*([?[:alpha:]0-9'`^._ ]+)*",
                     "captures": {
                         "1": {
-                            "name": "keyword.symbol.fsharp"
+                            "name": "keyword.symbol.arrow.fsharp"
                         },
                         "2": {
                             "name": "keyword.symbol.fsharp"
@@ -1119,8 +1119,12 @@
                     "match": "\\b(match|yield|yield!|with|if|then|else|elif|for|in|return!|return|try|finally|while|do)(?!')\\b"
                 },
                 {
+                    "name": "keyword.symbol.arrow.fsharp",
+                    "match": "(\\->|\\<\\-)"
+                },
+                {
                     "name": "keyword.symbol.fsharp",
-                    "match": "(&&&|\\|\\|\\||\\^\\^\\^|~~~|<<<|>>>|\\|>|\\->|\\<\\-|:>|:\\?>|:|\\[|\\]|\\;|<>|=|@|\\|\\||&&|{|}|\\||_|\\.\\.|\\,|\\+|\\-|\\*|\\/|\\^|\\!|\\>|\\>\\=|\\>\\>|\\<|\\<\\=|\\(|\\)|\\<\\<)"
+                    "match": "(&&&|\\|\\|\\||\\^\\^\\^|~~~|<<<|>>>|\\|>|:>|:\\?>|:|\\[|\\]|\\;|<>|=|@|\\|\\||&&|{|}|\\||_|\\.\\.|\\,|\\+|\\-|\\*|\\/|\\^|\\!|\\>|\\>\\=|\\>\\>|\\<|\\<\\=|\\(|\\)|\\<\\<)"
                 }
             ]
         },
@@ -1345,7 +1349,7 @@
                     "end": "(>)",
                     "beginCaptures": {
                         "1": {
-                            "name": "keyword.symbol.fsharp"
+                            "name": "keyword.symbol.arrow.fsharp"
                         },
                         "2": {
                             "name": "entity.name.type.fsharp"
@@ -1377,7 +1381,7 @@
                     "match": "\\s*(->)\\s*(?!with|get|set\\b)\\b([\\w0-9'`^._]+)",
                     "captures": {
                         "1": {
-                            "name": "keyword.symbol.fsharp"
+                            "name": "keyword.symbol.arrow.fsharp"
                         },
                         "2": {
                             "name": "entity.name.type.fsharp"

--- a/sample-code/SimpleBindings.fs
+++ b/sample-code/SimpleBindings.fs
@@ -169,3 +169,29 @@ module EqualSignTest =
         bop (x - 1)
     and bop y =
         if (y = 0) then 0 else bee y
+
+// Make sure the arrow symbols `<-` and `->` are all the same color. If the
+// user sets a custom color for `keyword.symbol.arrow`, then all the arrows
+// should be that color. If the user does not set an explicit configuration
+// for the arrow color, then all the arrows should be the same color as all
+// the other operator symbols (i.e. the `keyword.symbol` color).
+module ArrowTest =
+
+    let mutable foo1 = 0
+
+    foo1 <- 1
+
+    let foo2 = (fun () -> 123)
+    let foo3 = (fun x -> 456)
+    let foo4 : (unit -> unit) = id
+    let foo5 =
+        match foo1 with
+        | 0 -> ()
+        | _ -> ()
+
+    [<AbstractClass>]
+    type FooWithArrows(item : unit -> unit) =
+        abstract member Bar : unit -> unit
+        abstract member Baz : unit -> array<int>
+        member this.Boo : unit -> unit = id
+        member this.Goo : unit -> array<int> = failwith "foo"


### PR DESCRIPTION
The arrow symbols `<-` and `->` are not getting tokenized consistently. There are two different token names being assigned, depending on the context:

* `keyword.symbol.fsharp`
* `keyword.symbol.arrow.fsharp`

It would make sense for the `keyword.symbol.arrow.fsharp` token name to be consistently applied. See screenshots below.

Before:
![shot-1](https://github.com/ionide/ionide-fsgrammar/assets/1977895/16c43140-6b59-428e-8cc0-d3fb85ac2b74)

After:
![shot-2](https://github.com/ionide/ionide-fsgrammar/assets/1977895/0e1347ac-5945-4c4f-9f17-51266ef52540)

Here are the relevant VS Code color settings for this example:

    "editor.tokenColorCustomizations": {
        "textMateRules": [
            {
                "scope": [
                    "source.fsharp keyword"
                ],
                "settings": {
                    "foreground": "#569cd6"
                }
            },
            {
                "scope": [
                    "source.fsharp constant.language.unit",
                    "source.fsharp keyword.symbol"
                ],
                "settings": {
                    "foreground": "#d4d4d4"
                }
            },
            {
                "scope": [
                    "source.fsharp keyword.symbol.arrow"
                ],
                "settings": {
                    "foreground": "#ff8080"
                }
            }
        ]
    }

Because `keyword.symbol.arrow` is a descendant of `keyword.symbol`, the arrow symbols will just get the regular symbol operator color if the user does not configure a special color for the arrow symbols. Users who do have an explicit setting for the arrow color will see consistent behavior with these changes in effect. I think the correct behavior here is something that will be appreciated by users who might have grown accustomed to the syntax coloring in Visual Studio (i.e. classic Visual Studio, not VS Code). With F#, Visual Studio always makes arrows the same color as keywords, not the same color as operator symbols. See screenshot below.

![shot-3](https://github.com/ionide/ionide-fsgrammar/assets/1977895/b3f41211-ab47-42fb-967f-0af057d2e127)

With the changes in this PR in effect, Ionide users can configure their arrow color settings to match the style of Visual Studio. And since the arrow colors can be configured independently of both keyword and operator symbol colors, Ionide can boast a level of flexibility not available in Visual Studio.