### PR TITLE
Fix inconsistent tokens for parentheses in unit literals

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -606,7 +606,7 @@
         "constants": {
             "patterns": [
                 {
-                    "name": "constant.language.unit.fsharp",
+                    "name": "keyword.symbol.fsharp",
                     "match": "\\(\\)"
                 },
                 {
@@ -1326,7 +1326,7 @@
         "variables": {
             "patterns": [
                 {
-                    "name": "constant.language.unit.fsharp",
+                    "name": "keyword.symbol.fsharp",
                     "match": "\\(\\)"
                 },
                 {
@@ -1584,7 +1584,7 @@
                             "name": "keyword.symbol.fsharp"
                         },
                         "7": {
-                            "name": "constant.language.unit.fsharp"
+                            "name": "keyword.symbol.fsharp"
                         }
                     },
                     "patterns": [

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -762,6 +762,26 @@ type FooWithSpaceAfterNew =
     new () = { a = 0 }
     new (b) = { a = b }
 
+// Opening and closing parentheses associated with tuples, unit literals,
+// and parameters should be colored consistently.
+
+let parensFoo1 = ()
+let parensFoo2 = ( )
+let parensFoo3 = (1)
+let parensFoo4 = (2, 3)
+let parensFoo5 = (), ()
+let parensFoo6 = ((), ())
+let parensFoo7 = DateTime()
+let parensFoo8 = DateTime(456)
+
+let parensBar1 () = "foo"
+let parensBar2 ( ) = "bar"
+let parensBar3 (x) = "baz"
+
+type ParensBaz1() = class end
+type ParensBaz2( ) = class end
+type ParensBaz3(x) = class end
+
 // The opening and closing angle brackets `<` and `>` for generics should
 // always use the symbol color and not the keyword color. Also, the colon
 // symbol `:` and casting operator `:>` should use the symbol color.


### PR DESCRIPTION
Parentheses used for the unit literal `()` are not getting tokenized consistently. There are two different token names being assigned, depending on the context:

* `keyword.symbol.fsharp`
* `constant.language.unit.fsharp`

I think the use of `keyword.symbol.fsharp` is the correct treatment. While a technical argument can be made for classifying the unit literal as a constant, it doesn't really fit the predominant conventions being used for the syntax coloring. It looks like the use of `constant.language.unit.fsharp` is a holdover from before the current conventions were established.

See comment here:

https://github.com/ionide/ionide-fsgrammar/issues/87#issue-341007201

Specifically this part:

> ... every parenthesis (except for unit, weirdly) etc. This doesn’t look as awesome.

Following the [principle of least surprise](https://en.wikipedia.org/wiki/Principle_of_least_astonishment), I think it makes sense for unit literals to be styled as if they were empty tuples. I think that's what most people would expect. See the "before" and "after" screenshots below. Note the oddballs on lines 757, 768, 772, 774, 777, and 781.

Before:
![shot-1](https://github.com/ionide/ionide-fsgrammar/assets/1977895/62d7361f-2958-418b-8e11-653aff9f9261)

After:
![shot-2](https://github.com/ionide/ionide-fsgrammar/assets/1977895/cb7c737b-5d3e-4cf9-bbee-5245be5766cb)

If you're using the default theme in VS Code, these inconsistencies won't be visible unless you explicitly override the operator symbol color. You can use something like the following in your VS Code settings to reproduce the examples above:

    "editor.tokenColorCustomizations": {
        "[Default Dark+]": {
            "textMateRules": [

                // ...

                {
                    "scope": [
                        "source.fsharp keyword.symbol"
                    ],
                    "settings": {
                        "foreground": "#ffff80"
                    }
                },

                // ...
            ]
        }
    },

Even if you don't customize your color settings, you can still see these inconsistencies with some of the built-in themes that come with VS Code. See screenshots below.

Before:
![shot-3](https://github.com/ionide/ionide-fsgrammar/assets/1977895/a79c83c1-e856-4801-a685-d9beb71bcb71)

After:
![shot-4](https://github.com/ionide/ionide-fsgrammar/assets/1977895/c1a286b7-26b8-4d46-939c-7ecb518c8da5)

As you can see above, these inconsistencies can show up even when using out-of-the-box themes with no additional customizations. The changes in this PR only affect the token names. There are no changes to the regular expressions.