### PR TITLE
Treat unit as a type instead of a constant

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -623,7 +623,7 @@
                 },
                 {
                     "name": "constant.other.fsharp",
-                    "match": "\\b(null|unit|void)\\b"
+                    "match": "\\b(null|void)\\b"
                 }
             ]
         },

--- a/sample-code/SimpleBindings.fs
+++ b/sample-code/SimpleBindings.fs
@@ -195,3 +195,19 @@ module ArrowTest =
         abstract member Baz : unit -> array<int>
         member this.Boo : unit -> unit = id
         member this.Goo : unit -> array<int> = failwith "foo"
+
+// The word `unit` should be styled the same as built-in primitive types such
+// as `char`, `byte`, `int`, `float`, `bool`, etc.
+module UnitAsTypeTest =
+
+    let unit = "foo"
+    let char = "bar"
+    let byte = "baz"
+
+    let bing = unit
+    let bang = char
+    let boom = byte
+
+    let mike : unit = ()
+    let john : char = 'A'
+    let gary : byte = 0uy


### PR DESCRIPTION
The word `unit` is not a constant. It is a type. I think it should be treated the same as other built-in types such as `char`, `byte`, `int`, `float`, `bool`, etc. Note the difference on line 207 in the screenshots below.

Before:
![shot-1](https://github.com/ionide/ionide-fsgrammar/assets/1977895/ddc4a73c-6179-4aaf-8fa7-23fa80d5264a)

After:
![shot-2](https://github.com/ionide/ionide-fsgrammar/assets/1977895/f30926b8-7332-45ae-9202-c20abaf1c1e3)

The relevant VS Code color settings:

    "editor.tokenColorCustomizations": {
        "textMateRules": [

            // ...
            
            {
                "scope": [
                    "source.fsharp constant.other"
                ],
                "settings": {
                    "foreground": "#ce9178"
                }
            },

            // ...
        ]
    },
