### PR TITLE
Fix comment

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -313,7 +313,7 @@
                 },
                 {
                     "match": "(?!when|and|or\\b)\\b([\\w0-9'`^._]+)",
-                    "comments": "Here we need the \\w modifier in order to check that the words isn't blacklisted",
+                    "comments": "Here we need the \\w modifier in order to check that the words are allowed",
                     "captures": {
                         "1": {
                             "name": "entity.name.type.fsharp"


### PR DESCRIPTION
Hi, this PR adjusts a comment to resolve a downstream Policheck issue in microsoft/vscode.

Policheck is an internal tool used to scan for potentially sensitive terms. It flagged the file in this PR because we use it in our codebase, ref https://github.com/microsoft/vscode/blob/322bc2d7d86e8d0c2ccb1bfdabe594e2011d500f/extensions/fsharp/cgmanifest.json#L13.