### PR TITLE
match on back-tick escaped namespace and module names

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -1132,7 +1132,7 @@
             "patterns": [
                 {
                     "name": "entity.name.section.fsharp",
-                    "begin": "\\b(namespace global)|\\b(namespace|module)\\s*(public|internal|private|rec)?\\s+([[:alpha:]][[:alpha:]0-9'_. ]*)",
+                    "begin": "\\b(namespace global)|\\b(namespace|module)\\s*(public|internal|private|rec)?\\s+([[:alpha:]|``][[:alpha:]0-9'_. ]*)",
                     "end": "(\\s?=|\\s|$)",
                     "beginCaptures": {
                         "1": {
@@ -1170,7 +1170,7 @@
                 },
                 {
                     "name": "namespace.open.fsharp",
-                    "begin": "\\b(open type|open)\\s+([[:alpha:]][[:alpha:]0-9'_]*)(?=(\\.[A-Z][[:alpha:]0-9_]*)*)",
+                    "begin": "\\b(open type|open)\\s+([[:alpha:]|``][[:alpha:]0-9'_]*)(?=(\\.[A-Z][[:alpha:]0-9_]*)*)",
                     "end": "(\\s|$)",
                     "beginCaptures": {
                         "1": {


### PR DESCRIPTION
Before:
![image](https://github.com/ionide/ionide-fsgrammar/assets/3221269/8bac620a-b922-46eb-8464-efda0533c1cd)

After:
![image](https://github.com/ionide/ionide-fsgrammar/assets/3221269/ef7f846b-b9c5-4b5a-ae64-c24c23d0cfc5)
