### PR TITLE
Fix colorisation when declaring abstract member with generics types

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -629,7 +629,7 @@
         },
         "abstract_definition": {
             "name": "abstract.definition.fsharp",
-            "begin": "\\b(abstract)\\s+(member)?(\\s+\\[\\<.*\\>\\])?\\s*([_[:alpha:]0-9,\\._`\\s]+)(:)",
+            "begin": "\\b(abstract)\\s+(member)?(\\s+\\[\\<.*\\>\\])?\\s*([_[:alpha:]0-9,\\._`\\s]+)(<)?",
             "end": "\\s*(with)\\b|=|$",
             "beginCaptures": {
                 "1": {
@@ -675,7 +675,7 @@
                     }
                 },
                 {
-                    "match": "(?!with|get|set\\b)\\b([\\w0-9'`^._]+)",
+                    "match": "(?!with|get|set\\b)\\s*([\\w0-9'`^._]+)",
                     "comments": "Here we need the \\w modifier in order to check that the words isn't blacklisted",
                     "captures": {
                         "1": {

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -309,9 +309,11 @@ type T =
     abstract Test : Result<string list, int array>
     abstract Test2 : mode: float * test : (Result<Result<Result<Result<string, string>, string>, string> list, int array> * int)
     abstract TupleOfTuples : (int * (int * (Result<Result<Result<Result<string, string>, string>, string> list, int array> * int)))
+    abstract Decode<'Json> : spaces : int -> string // Should trigger generic coloration and have int colored as type
+    abstract member Decode2<'Json, 'Output> : spaces : int -> string// This was breaking coloration of lines below
 
 type FancyClass with
-    member __.Run (program : Program<'arg, 'model, 'msg, array<'view>>) = ()
+    member __.Run<'JsonValue> (program : Program<'arg, 'model, 'msg, array<'view>>) = ()
 
 type FancyClass1(?thing:int) =
     class end
@@ -883,3 +885,6 @@ let genericFunc3<'a when 'a : enum<int>> (x : 'a) = x
 
 type AbstractType =
     abstract member Foo : unit -> unit
+
+
+type DecoderError<'JsonValue> = string * ErrorReason<'JsonValue>


### PR DESCRIPTION
Fix #204

**Before**
![CleanShot 2023-11-17 at 16 41 20](https://github.com/ionide/ionide-fsgrammar/assets/4760796/395eafa0-ec24-490e-a23e-e491c646d979)

**After**
![CleanShot 2023-11-17 at 16 41 59](https://github.com/ionide/ionide-fsgrammar/assets/4760796/36c3845c-3fad-4356-a178-a6226f1fdb85)
