### PR TITLE
Fix ionide#207: Capture (*) inside block comment

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -574,6 +574,11 @@
                             "match": "//"
                         },
                         {
+                            "comments": "Capture (*) when inside of (* *) so that it doesn't prematurely end the comment block.",
+                            "name": "fast-capture.comment.line.mul-operator.fsharp",
+                            "match": "\\(\\*\\)"
+                        },
+                        {
                             "include": "#comments"
                         }
                     ]

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -65,6 +65,10 @@ file as markdown
 
     (* Unbalanced comment, which turn everything after itself into comment **)
     let e = (* comment// *) "not a comment"
+    
+    // The infix multiplication operator (*) should not be parsed as the end of a 
+    // block comment.
+    (* (*) "This text is a comment" (*) *)
 
 /// **Description**
 ///


### PR DESCRIPTION
The infix multiplication operator `(*)` is specified by the language spec as being a symbolic keyword (§3.6). According to §3.2, this means that the entire operator should be parsed as a token and discarded.

**Before:**
![image](https://github.com/ionide/ionide-fsgrammar/assets/6901247/30371cc1-052f-4672-a97a-8f3d6693b455)

**After:**
![image](https://github.com/ionide/ionide-fsgrammar/assets/6901247/958d169e-ef91-435f-a0b4-3e2867c2330e)


This fixes half of #207.