### PR TITLE
Support `static abstract` member declarations

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -644,6 +644,9 @@
                     "name": "keyword.fsharp"
                 },
                 "3": {
+                    "name": "keyword.fsharp"
+                },
+                "4": {
                     "name": "support.function.attribute.fsharp"
                 },
                 "5": {

--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -634,7 +634,7 @@
         },
         "abstract_definition": {
             "name": "abstract.definition.fsharp",
-            "begin": "\\b(abstract)\\s+(member)?(\\s+\\[\\<.*\\>\\])?\\s*([_[:alpha:]0-9,\\._`\\s]+)(<)?",
+            "begin": "\\b(static)?\\s+(abstract)\\s+(member)?(\\s+\\[\\<.*\\>\\])?\\s*([_[:alpha:]0-9,\\._`\\s]+)(<)?",
             "end": "\\s*(with)\\b|=|$",
             "beginCaptures": {
                 "1": {

--- a/sample-code/SimpleBindings.fs
+++ b/sample-code/SimpleBindings.fs
@@ -224,3 +224,9 @@ module UnitAsTypeTest =
     let mike : unit = ()
     let john : char = 'A'
     let gary : byte = 0uy
+
+#nowarn "3535"
+
+type IFace =
+    static abstract M : unit
+    static abstract member N : unit


### PR DESCRIPTION
```fsharp
#nowarn "3535"

type IFace =
    static abstract M : unit
    static abstract member N : unit
```

### Before

![image](https://github.com/ionide/ionide-fsgrammar/assets/14795984/06ce573d-5526-4be4-817e-843f7ce8b4d5)

### After

![image](https://github.com/ionide/ionide-fsgrammar/assets/14795984/3483863e-b305-4ee7-8a75-1417385e325a)
