### PR TITLE
Handle SRTPs in sig files

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -718,7 +718,7 @@
                             "name": "keyword.fsharp"
                         }
                     },
-                    "end": "(\\))\\s*((?=,)|(?=\\=))",
+                    "end": "(\\))\\s*((?=,)|(?=\\=))?",
                     "endCaptures": {
                         "1": {
                             "name": "keyword.symbol.fsharp"

--- a/sample-code/SimpleBindings.fs
+++ b/sample-code/SimpleBindings.fs
@@ -36,6 +36,10 @@ let e_float64    = 0x0000000000000000LF
 
 let a_bigint     = 304554I
 
+let inline s (array: ^T array -> ^T when ^T: (static member (+): ^T * ^T -> ^T)) = ignore array
+let p = 3
+let q = p
+
 let π = 3.1415
 
 

--- a/sample-code/SimpleBindings.fsi
+++ b/sample-code/SimpleBindings.fsi
@@ -31,3 +31,12 @@ module SimpleBindings =
     val e_float64    : float
     val a_bigint     : bigint
 
+    // The highlighting used to go awry starting after the (static member (+): ^T * ^T -> ^T).
+    val inline s: array: ^T array -> ^T when ^T: (static member (+): ^T * ^T -> ^T)
+
+    // This used to be highlighted wrong.
+    val p : int
+
+    // This comment has two magic characters in it, which fixed things:
+    // )=
+    val q : int


### PR DESCRIPTION
- End SRTP matching even when there is no `=` after the `)` of a `(member … : …)`.

This is a bug that you will notice if you look at many signature files in FSharp.Core, [for example](https://github.com/dotnet/fsharp/blob/324ba3dd76e4b7c24cecf838ee0251a12126ca67/src/FSharp.Core/array.fsi#L81-L90).

I tried this out on FSharp.Core, and everything looked good as far as I could tell, but the SRTP patterns are complicated, so I hope this change doesn't break something else.

```fsi
// The highlighting goes awry starting after the "(static member (+): ^T * ^T -> ^T)".
// Notice how the first ^T in "and ^T: (static member Zero: ^T)" is not the right color.
val inline s: array: ^T array -> ^T when ^T: (static member (+): ^T * ^T -> ^T) and ^T: (static member Zero: ^T)

// This is still highlighted wrong.
val p : int

// This comment has two magic characters in it, which fix things:
// )=
val q : int
```

### Before

![Screenshot 2024-06-05 174607](https://github.com/ionide/ionide-fsgrammar/assets/14795984/c89f3813-6f3f-4f6a-9bb3-2764548c23ec)

### After

![Screenshot 2024-06-05 174723](https://github.com/ionide/ionide-fsgrammar/assets/14795984/7d5300e1-5b40-4610-a616-713dcc91d1b6)
