### PR TITLE
Support `val inline` in sig files

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -1010,7 +1010,7 @@
                 },
                 {
                     "name": "binding.fsharp",
-                    "begin": "\\b(static val mutable|val mutable|val)(\\s+rec|mutable)?(\\s+\\[\\<.*\\>\\])?\\s*(private|internal|public)?\\s+(\\[[^-=]*\\]|[_[:alpha:]]([_[:alpha:]0-9,\\._]+)*|``[_[:alpha:]]([_[:alpha:]0-9,\\._`\\s]+|(?<=,)\\s)*)?",
+                    "begin": "\\b(static val mutable|val mutable|val inline|val)(\\s+rec|mutable)?(\\s+\\[\\<.*\\>\\])?\\s*(private|internal|public)?\\s+(\\[[^-=]*\\]|[_[:alpha:]]([_[:alpha:]0-9,\\._]+)*|``[_[:alpha:]]([_[:alpha:]0-9,\\._`\\s]+|(?<=,)\\s)*)?",
                     "end": "\\n$",
                     "beginCaptures": {
                         "1": {

--- a/sample-code/SimpleBindings.fs
+++ b/sample-code/SimpleBindings.fs
@@ -230,3 +230,6 @@ module UnitAsTypeTest =
 type IFace =
     static abstract M : unit
     static abstract member N : unit
+
+let inline foo x = x
+let inline bar x = x

--- a/sample-code/SimpleBindings.fsi
+++ b/sample-code/SimpleBindings.fsi
@@ -31,3 +31,5 @@ module SimpleBindings =
     val e_float64    : float
     val a_bigint     : bigint
 
+    val inline foo : 'a -> 'a
+    val inline internal bar : 'a -> 'a


### PR DESCRIPTION
### Before

![Screenshot 2024-06-05 181437](https://github.com/ionide/ionide-fsgrammar/assets/14795984/f23ce04b-aa7f-461f-b106-5cd4d036e8af)

### After

![Screenshot 2024-06-05 181403](https://github.com/ionide/ionide-fsgrammar/assets/14795984/fef527db-f43f-4c30-924a-524efc64ac56)