### PR TITLE
Support `member inline`

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -935,7 +935,7 @@
             "patterns": [
                 {
                     "name": "binding.fsharp",
-                    "begin": "\\b(let mutable|static let mutable|static let|let inline|let|and|member val|static member inline|static member|default|member|override|let!)(\\s+rec|mutable)?(\\s+\\[\\<.*\\>\\])?\\s*(private|internal|public)?\\s+(\\[[^-=]*\\]|[_[:alpha:]]([_[:alpha:]0-9\\._]+)*|``[_[:alpha:]]([_[:alpha:]0-9\\._`\\s]+|(?<=,)\\s)*)?",
+                    "begin": "\\b(let mutable|static let mutable|static let|let inline|let|and|member val|member inline|static member inline|static member|default|member|override|let!)(\\s+rec|mutable)?(\\s+\\[\\<.*\\>\\])?\\s*(private|internal|public)?\\s+(\\[[^-=]*\\]|[_[:alpha:]]([_[:alpha:]0-9\\._]+)*|``[_[:alpha:]]([_[:alpha:]0-9\\._`\\s]+|(?<=,)\\s)*)?",
                     "end": "\\s*((with\\b)|(=|\\n+=|(?<=\\=)))",
                     "beginCaptures": {
                         "1": {

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -259,6 +259,9 @@ type FancyClass(thing:int, var2 : string -> string, ``ddzdz``: string list, extr
     static member (< ) (v1 : int, v2 : int) = v2 < v2
     static member (<|>) (v1 : int, v2 : int) = v2 < v2
 
+    member inline _.Q () = 3
+    member inline internal _.P () = 3
+
 let inline internal (<) (x : int) ys = x + ys
 let (< ) (x : int) ys = x + ys
 let (<<.) a = 1


### PR DESCRIPTION
### Before

![Screenshot 2024-06-06 113959](https://github.com/ionide/ionide-fsgrammar/assets/14795984/b8487927-54a4-4c67-a9d5-0b04d969a3ed)

### After

![Screenshot 2024-06-06 113920](https://github.com/ionide/ionide-fsgrammar/assets/14795984/3957d890-24e8-4ba9-84b5-ae73a7345d12)