### PR TITLE
Fix `(static) abstract member` declarations

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -634,7 +634,7 @@
         },
         "abstract_definition": {
             "name": "abstract.definition.fsharp",
-            "begin": "\\b(static)?\\s+(abstract)\\s+(member)?(\\s+\\[\\<.*\\>\\])?\\s*([_[:alpha:]0-9,\\._`\\s]+)(<)?",
+            "begin": "\\b(static\\s+)?(abstract)\\s+(member)?(\\s+\\[\\<.*\\>\\])?\\s*([_[:alpha:]0-9,\\._`\\s]+)(<)?",
             "end": "\\s*(with)\\b|=|$",
             "beginCaptures": {
                 "1": {


### PR DESCRIPTION
#212 introduced support for `static abstract`, but in doing so accidentally required the space (`\s+`) before the `abstract`, breaking `abstract member`. This PR makes it so we only expect the `\s+` if we've seen `static`.

Before the change:
 
![image](https://github.com/user-attachments/assets/8ce2f965-26be-4a8b-8174-582e1f728fc4)

After the change:

![image](https://github.com/user-attachments/assets/edf15c86-4059-4ac6-9ecd-36fa510c599e)
