### PR TITLE
fix: `inline` on getter/setter

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -935,8 +935,8 @@
             "patterns": [
                 {
                     "name": "binding.fsharp",
-                    "begin": "\\b(let mutable|static let mutable|static let|let inline|let|and|member val|member inline|static member inline|static member val|static member|default|member|override|let!)(\\s+rec|mutable)?(\\s+\\[\\<.*\\>\\])?\\s*(private|internal|public)?\\s+(\\[[^-=]*\\]|[_[:alpha:]]([_[:alpha:]0-9\\._]+)*|``[_[:alpha:]]([_[:alpha:]0-9\\._`\\s]+|(?<=,)\\s)*)?",
-                    "end": "\\s*((with\\b)|(=|\\n+=|(?<=\\=)))",
+                    "begin": "\\b(let mutable|static let mutable|static let|let inline|let|and inline|and|member val|member inline|static member inline|static member val|static member|default|member|override|let!)(\\s+rec|mutable)?(\\s+\\[\\<.*\\>\\])?\\s*(private|internal|public)?\\s+(\\[[^-=]*\\]|[_[:alpha:]]([_[:alpha:]0-9\\._]+)*|``[_[:alpha:]]([_[:alpha:]0-9\\._`\\s]+|(?<=,)\\s)*)?",
+                    "end": "\\s*((with inline|with)\\b|(=|\\n+=|(?<=\\=)))",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.fsharp"

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -264,6 +264,10 @@ type FancyClass(thing:int, var2 : string -> string, ``ddzdz``: string list, extr
     member inline _.Q () = 3
     member inline internal _.P () = 3
 
+    member this.Value
+        with inline get() = ()
+        and inline set v = ()
+
 let inline internal (<) (x : int) ys = x + ys
 let (< ) (x : int) ys = x + ys
 let (<<.) a = 1


### PR DESCRIPTION
Fix #227

**Before**

<img width="465" height="118" alt="image" src="https://github.com/user-attachments/assets/75c9180d-690a-4e55-9947-93040c9ff430" />


**After**

<img width="410" height="100" alt="image" src="https://github.com/user-attachments/assets/42a98943-371a-4caa-954c-a41b90d4464a" />
