### PR TITLE
feat: add support for `| null` highlighting

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -806,12 +806,15 @@
                     ]
                 },
                 {
-                    "match": "(:)\\s*([?[:alpha:]0-9'`^._ ]+)",
+                    "match": "(:)\\s*([?[:alpha:]0-9'`^._ ]+)(\\|\\s*(null))?",
                     "captures": {
                         "1": {
                             "name": "keyword.symbol.fsharp"
                         },
                         "2": {
+                            "name": "entity.name.type.fsharp"
+                        },
+                        "4": {
                             "name": "entity.name.type.fsharp"
                         }
                     }
@@ -1521,7 +1524,7 @@
                     "match": "(\\(|\\))"
                 },
                 {
-                    "match": "(\\?{0,1})([[:alpha:]0-9'`^._]+|``[[:alpha:]0-9'`^:,._ ]+``)\\s*(:{0,1})(\\s*([?[:alpha:]0-9'`<>._ ]+)){0,1}",
+                    "match": "(\\?{0,1})([[:alpha:]0-9'`^._]+|``[[:alpha:]0-9'`^:,._ ]+``)\\s*(:{0,1})(\\s*([?[:alpha:]0-9'`<>._ ]+)){0,1}(\\|\\s*(null))?",
                     "captures": {
                         "1": {
                             "name": "keyword.symbol.fsharp"
@@ -1533,6 +1536,9 @@
                             "name": "keyword.symbol.fsharp"
                         },
                         "4": {
+                            "name": "entity.name.type.fsharp"
+                        },
+                        "7": {
                             "name": "entity.name.type.fsharp"
                         }
                     }

--- a/sample-code/SimpleTypes.fs
+++ b/sample-code/SimpleTypes.fs
@@ -901,3 +901,21 @@ type AbstractType =
 
 
 type DecoderError<'JsonValue> = string * ErrorReason<'JsonValue>
+
+// Nullness related
+
+let myNullValue : objnull = null
+
+type NullnessConstraint<'T when 'T : null> =
+    class end
+
+// Check that we don't break the non nullness case
+let toUpperString (txt : string) = ()
+
+let toUpper (txt : string | null) = ()
+
+let toUpperLambda = 
+    fun (txt: string | null) -> ()
+
+type StringHelper =
+    member this.ToUpper (txt : string | null) = ()


### PR DESCRIPTION
Fix #225

**Before**

<img width="579" height="413" alt="image" src="https://github.com/user-attachments/assets/a89ebee6-bc62-49f3-8ddf-0b0ccad83145" />

**After**

<img width="544" height="407" alt="image" src="https://github.com/user-attachments/assets/a2f65a18-a319-4af2-bb8a-8745298cd0dc" />
