### PR TITLE
fix: remove non-needed comment patterns + rewrite invalid `endCaptures` to `whileCaptures`

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -525,15 +525,6 @@
         "comments": {
             "patterns": [
                 {
-                    "name": "comment.literate.command.fsharp",
-                    "match": "(\\(\\*{3}.*\\*{3}\\))",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "comment.block.fsharp"
-                        }
-                    }
-                },
-                {
                     "name": "comment.block.markdown.fsharp",
                     "begin": "^\\s*(\\(\\*\\*(?!\\)))((?!\\*\\)).)*$",
                     "while": "^(?!\\s*(\\*)+\\)\\s*$)",
@@ -542,7 +533,7 @@
                             "name": "comment.block.fsharp"
                         }
                     },
-                    "endCaptures": {
+                    "whileCaptures": {
                         "1": {
                             "name": "comment.block.fsharp"
                         }


### PR DESCRIPTION
Fix #206

These changes caused no visual changes to the grammar, they are here just for doing some cleanup