### PR TITLE
add #warnon

### DIFF
--- a/grammars/fsharp.json
+++ b/grammars/fsharp.json
@@ -1830,7 +1830,7 @@
             "patterns": [
                 {
                     "name": "keyword.control.directive.fsharp",
-                    "match": "\\s?(#if|#elif|#elseif|#else|#endif|#light|#nowarn)",
+                    "match": "\\s?(#if|#elif|#elseif|#else|#endif|#light|#nowarn|#warnon)",
                     "captures": {}
                 }
             ]


### PR DESCRIPTION
Support the new #warnon directive.
(Available in F# 10, but doesn't hurt in earlier versions)